### PR TITLE
Remove extra scripts entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.0.3",
   "description": "Kerberos library for Node.js",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/christkv/kerberos.git"


### PR DESCRIPTION
`package.json` has an extra `scripts` entry.

It seems to be the default for `npm init` when you don't specify a test script.
I'm guessing this is unnecessary?

Cheers! :beers:
