### PR TITLE
Implement the authGSSServer* methods

### DIFF
--- a/lib/kerberos.cc
+++ b/lib/kerberos.cc
@@ -44,6 +44,19 @@ typedef struct AuthGSSClientCleanCall {
   KerberosContext *context;
 } AuthGSSClientCleanCall;
 
+typedef struct AuthGSSServerInitCall {
+  char *service;
+} AuthGSSServerInitCall;
+
+typedef struct AuthGSSServerCleanCall {
+  KerberosContext *context;
+} AuthGSSServerCleanCall;
+
+typedef struct AuthGSSServerStepCall {
+  KerberosContext *context;
+  char *challenge;
+} AuthGSSServerStepCall;
+
 Kerberos::Kerberos() : ObjectWrap() {
 }
 
@@ -64,6 +77,9 @@ void Kerberos::Initialize(v8::Handle<v8::Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "authGSSClientUnwrap", AuthGSSClientUnwrap);
   NODE_SET_PROTOTYPE_METHOD(t, "authGSSClientWrap", AuthGSSClientWrap);
   NODE_SET_PROTOTYPE_METHOD(t, "authGSSClientClean", AuthGSSClientClean);
+  NODE_SET_PROTOTYPE_METHOD(t, "authGSSServerInit", AuthGSSServerInit);
+  NODE_SET_PROTOTYPE_METHOD(t, "authGSSServerClean", AuthGSSServerClean);
+  NODE_SET_PROTOTYPE_METHOD(t, "authGSSServerInit", AuthGSSServerInit);
 
   NanAssignPersistent(constructor_template, t);
 
@@ -126,7 +142,7 @@ NAN_METHOD(Kerberos::AuthGSSClientInit) {
 
   // Ensure valid call
   if(args.Length() != 3) return NanThrowError("Requires a service string uri, integer flags and a callback function");
-  if(args.Length() == 3 && !args[0]->IsString() && !args[1]->IsInt32() && !args[2]->IsFunction()) 
+  if(args.Length() == 3 && (!args[0]->IsString() || !args[1]->IsInt32() || !args[2]->IsFunction()))
       return NanThrowError("Requires a service string uri, integer flags and a callback function");    
 
   Local<String> service = args[0]->ToString();
@@ -211,14 +227,16 @@ NAN_METHOD(Kerberos::AuthGSSClientStep) {
 
   // Ensure valid call
   if(args.Length() != 2 && args.Length() != 3) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
-  if(args.Length() == 2 && !KerberosContext::HasInstance(args[0])) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
-  if(args.Length() == 3 && !KerberosContext::HasInstance(args[0]) && !args[1]->IsString()) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
+  if(args.Length() == 2 && (!KerberosContext::HasInstance(args[0]) || !args[1]->IsFunction())) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
+  if(args.Length() == 3 && (!KerberosContext::HasInstance(args[0]) || !args[1]->IsString() || !args[2]->IsFunction())) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
 
   // Challenge string
   char *challenge_str = NULL;
   // Let's unpack the parameters
   Local<Object> object = args[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
+
+  int callbackArg = 1;
 
   // If we have a challenge string
   if(args.Length() == 3) {
@@ -228,17 +246,19 @@ NAN_METHOD(Kerberos::AuthGSSClientStep) {
     challenge_str = (char *)calloc(challenge->Utf8Length() + 1, sizeof(char));
     if(challenge_str == NULL) die("Memory allocation failed");
     // Write v8 string to c-string
-    challenge->WriteUtf8(challenge_str);    
+    challenge->WriteUtf8(challenge_str);
+
+    callbackArg = 2;
   }
 
   // Allocate a structure
-  AuthGSSClientStepCall *call = (AuthGSSClientStepCall *)calloc(1, sizeof(AuthGSSClientCall));
+  AuthGSSClientStepCall *call = (AuthGSSClientStepCall *)calloc(1, sizeof(AuthGSSClientStepCall));
   if(call == NULL) die("Memory allocation failed");
   call->context = kerberos_context;
   call->challenge = challenge_str;
 
   // Unpack the callback
-  Local<Function> callbackHandle = Local<Function>::Cast(args[2]);
+  Local<Function> callbackHandle = Local<Function>::Cast(args[callbackArg]);
   NanCallback *callback = new NanCallback(callbackHandle);
 
   // Let's allocate some space
@@ -303,8 +323,8 @@ NAN_METHOD(Kerberos::AuthGSSClientUnwrap) {
 
   // Ensure valid call
   if(args.Length() != 2 && args.Length() != 3) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
-  if(args.Length() == 2 && !KerberosContext::HasInstance(args[0]) && !args[1]->IsFunction()) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
-  if(args.Length() == 3 && !KerberosContext::HasInstance(args[0]) && !args[1]->IsString() && !args[2]->IsFunction()) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
+  if(args.Length() == 2 && (!KerberosContext::HasInstance(args[0]) || !args[1]->IsFunction())) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
+  if(args.Length() == 3 && (!KerberosContext::HasInstance(args[0]) || !args[1]->IsString() || !args[2]->IsFunction())) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
 
   // Challenge string
   char *challenge_str = NULL;
@@ -397,8 +417,8 @@ NAN_METHOD(Kerberos::AuthGSSClientWrap) {
 
   // Ensure valid call
   if(args.Length() != 3 && args.Length() != 4) return NanThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
-  if(args.Length() == 3 && !KerberosContext::HasInstance(args[0]) && !args[1]->IsString() && !args[2]->IsFunction()) return NanThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
-  if(args.Length() == 4 && !KerberosContext::HasInstance(args[0]) && !args[1]->IsString() && !args[2]->IsString() && !args[2]->IsFunction()) return NanThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
+  if(args.Length() == 3 && (!KerberosContext::HasInstance(args[0]) || !args[1]->IsString() || !args[2]->IsFunction())) return NanThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
+  if(args.Length() == 4 && (!KerberosContext::HasInstance(args[0]) || !args[1]->IsString() || !args[2]->IsString() || !args[3]->IsFunction())) return NanThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
 
   // Challenge string
   char *challenge_str = NULL;
@@ -455,7 +475,7 @@ NAN_METHOD(Kerberos::AuthGSSClientWrap) {
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-// authGSSClientWrap
+// authGSSClientClean
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 static void _authGSSClientClean(Worker *worker) {
   gss_client_response *response;
@@ -492,7 +512,7 @@ NAN_METHOD(Kerberos::AuthGSSClientClean) {
 
   // // Ensure valid call
   if(args.Length() != 2) return NanThrowError("Requires a GSS context and callback function");
-  if(!KerberosContext::HasInstance(args[0]) && !args[1]->IsFunction()) return NanThrowError("Requires a GSS context and callback function");
+  if(!KerberosContext::HasInstance(args[0]) || !args[1]->IsFunction()) return NanThrowError("Requires a GSS context and callback function");
 
   // Let's unpack the kerberos context
   Local<Object> object = args[0]->ToObject();
@@ -515,6 +535,253 @@ NAN_METHOD(Kerberos::AuthGSSClientClean) {
   worker->parameters = call;
   worker->execute = _authGSSClientClean;
   worker->mapper = _map_authGSSClientClean;
+
+  // Schedule the worker with lib_uv
+  uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
+
+  // Return no value as it's callback based
+  NanReturnValue(NanUndefined());
+}
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// authGSSServerInit
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+static void _authGSSServerInit(Worker *worker) {
+  gss_server_state *state;
+  gss_client_response *response;
+
+  // Allocate state
+  state = (gss_server_state *)malloc(sizeof(gss_server_state));
+  if(state == NULL) die("Memory allocation failed");
+
+  // Unpack the parameter data struct
+  AuthGSSServerInitCall *call = (AuthGSSServerInitCall *)worker->parameters;
+  // Start the kerberos service
+  response = authenticate_gss_server_init(call->service, state);
+
+  // Release the parameter struct memory
+  free(call->service);
+  free(call);
+
+  // If we have an error mark worker as having had an error
+  if(response->return_code == AUTH_GSS_ERROR) {
+    worker->error = TRUE;
+    worker->error_code = response->return_code;
+    worker->error_message = response->message;
+    free(state);
+  } else {
+    worker->return_value = state;
+  }
+
+  // Free structure
+  free(response);
+}
+
+static Handle<Value> _map_authGSSServerInit(Worker *worker) {
+  KerberosContext *context = KerberosContext::New();
+  context->server_state = (gss_server_state *)worker->return_value;
+  return NanObjectWrapHandle(context);
+}
+
+// Server Initialize method
+NAN_METHOD(Kerberos::AuthGSSServerInit) {
+  NanScope();
+
+  // Ensure valid call
+  if(args.Length() != 2) return NanThrowError("Requires a service string service and a callback function");
+  if(!args[0]->IsString() || !args[1]->IsFunction()) return NanThrowError("Requires a service string service and a callback function");
+
+  Local<String> service = args[0]->ToString();
+  // Convert service string to c-string
+  char *service_str = (char *)calloc(service->Utf8Length() + 1, sizeof(char));
+  if(service_str == NULL) die("Memory allocation failed");
+
+  // Write v8 string to c-string
+  service->WriteUtf8(service_str);
+
+  // Allocate a structure
+  AuthGSSServerInitCall *call = (AuthGSSServerInitCall *)calloc(1, sizeof(AuthGSSServerInitCall));
+  if(call == NULL) die("Memory allocation failed");
+  call->service = service_str;
+
+  // Unpack the callback
+  Local<Function> callbackHandle = Local<Function>::Cast(args[1]);
+  NanCallback *callback = new NanCallback(callbackHandle);
+
+  // Let's allocate some space
+  Worker *worker = new Worker();
+  worker->error = false;
+  worker->request.data = worker;
+  worker->callback = callback;
+  worker->parameters = call;
+  worker->execute = _authGSSServerInit;
+  worker->mapper = _map_authGSSServerInit;
+
+  // Schedule the worker with lib_uv
+  uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
+  // Return no value as it's callback based
+  NanReturnValue(NanUndefined());
+}
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// authGSSServerClean
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+static void _authGSSServerClean(Worker *worker) {
+  gss_client_response *response;
+
+  // Unpack the parameter data struct
+  AuthGSSServerCleanCall *call = (AuthGSSServerCleanCall *)worker->parameters;
+
+  // Perform authentication step
+  response = authenticate_gss_server_clean(call->context->server_state);
+
+  // If we have an error mark worker as having had an error
+  if(response->return_code == AUTH_GSS_ERROR) {
+    worker->error = TRUE;
+    worker->error_code = response->return_code;
+    worker->error_message = response->message;
+  } else {
+    worker->return_code = response->return_code;
+  }
+
+  // Free up structure
+  free(call);
+  free(response);
+}
+
+static Handle<Value> _map_authGSSServerClean(Worker *worker) {
+  NanScope();
+  // Return the return code
+  return NanNew<Int32>(worker->return_code);
+}
+
+// Initialize method
+NAN_METHOD(Kerberos::AuthGSSServerClean) {
+  NanScope();
+
+  // // Ensure valid call
+  if(args.Length() != 2) return NanThrowError("Requires a GSS context and callback function");
+  if(!KerberosContext::HasInstance(args[0]) || !args[1]->IsFunction()) return NanThrowError("Requires a GSS context and callback function");
+
+  // Let's unpack the kerberos context
+  Local<Object> object = args[0]->ToObject();
+  KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
+
+  // Allocate a structure
+  AuthGSSServerCleanCall *call = (AuthGSSServerCleanCall *)calloc(1, sizeof(AuthGSSServerCleanCall));
+  if(call == NULL) die("Memory allocation failed");
+  call->context = kerberos_context;
+
+  // Unpack the callback
+  Local<Function> callbackHandle = Local<Function>::Cast(args[1]);
+  NanCallback *callback = new NanCallback(callbackHandle);
+
+  // Let's allocate some space
+  Worker *worker = new Worker();
+  worker->error = false;
+  worker->request.data = worker;
+  worker->callback = callback;
+  worker->parameters = call;
+  worker->execute = _authGSSServerClean;
+  worker->mapper = _map_authGSSServerClean;
+
+  // Schedule the worker with lib_uv
+  uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
+
+  // Return no value as it's callback based
+  NanReturnValue(NanUndefined());
+}
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// authGSSServerStep
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+static void _authGSSServerStep(Worker *worker) {
+  gss_server_state *state;
+  gss_client_response *response;
+  char *challenge;
+
+  // Unpack the parameter data struct
+  AuthGSSServerStepCall *call = (AuthGSSServerStepCall *)worker->parameters;
+  // Get the state
+  state = call->context->server_state;
+  challenge = call->challenge;
+
+  // Check what kind of challenge we have
+  if(call->challenge == NULL) {
+    challenge = (char *)"";
+  }
+
+  // Perform authentication step
+  response = authenticate_gss_server_step(state, challenge);
+
+  // If we have an error mark worker as having had an error
+  if(response->return_code == AUTH_GSS_ERROR) {
+    worker->error = TRUE;
+    worker->error_code = response->return_code;
+    worker->error_message = response->message;
+  } else {
+    worker->return_code = response->return_code;
+  }
+
+  // Free up structure
+  if(call->challenge != NULL) free(call->challenge);
+  free(call);
+  free(response);
+}
+
+static Handle<Value> _map_authGSSServerStep(Worker *worker) {
+  NanScope();
+  // Return the return code
+  return NanNew<Int32>(worker->return_code);
+}
+
+// Initialize method
+NAN_METHOD(Kerberos::AuthGSSServerStep) {
+  NanScope();
+
+  // Ensure valid call
+  if(args.Length() != 2 && args.Length() != 3) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
+  if(args.Length() == 2 && (!KerberosContext::HasInstance(args[0]) || !args[1]->IsFunction())) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
+  if(args.Length() == 3 && (!KerberosContext::HasInstance(args[0]) || !args[1]->IsString() || !args[2]->IsFunction())) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
+
+  // Challenge string
+  char *challenge_str = NULL;
+  // Let's unpack the parameters
+  Local<Object> object = args[0]->ToObject();
+  KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
+  int callbackArg = 1;
+
+  // If we have a challenge string
+  if(args.Length() == 3) {
+    // Unpack the challenge string
+    Local<String> challenge = args[1]->ToString();
+    // Convert uri string to c-string
+    challenge_str = (char *)calloc(challenge->Utf8Length() + 1, sizeof(char));
+    if(challenge_str == NULL) die("Memory allocation failed");
+    // Write v8 string to c-string
+    challenge->WriteUtf8(challenge_str);
+
+    callbackArg = 2;
+  }
+
+  // Allocate a structure
+  AuthGSSServerStepCall *call = (AuthGSSServerStepCall *)calloc(1, sizeof(AuthGSSServerStepCall));
+  if(call == NULL) die("Memory allocation failed");
+  call->context = kerberos_context;
+  call->challenge = challenge_str;
+
+  // Unpack the callback
+  Local<Function> callbackHandle = Local<Function>::Cast(args[callbackArg]);
+  NanCallback *callback = new NanCallback(callbackHandle);
+
+  // Let's allocate some space
+  Worker *worker = new Worker();
+  worker->error = false;
+  worker->request.data = worker;
+  worker->callback = callback;
+  worker->parameters = call;
+  worker->execute = _authGSSServerStep;
+  worker->mapper = _map_authGSSServerStep;
 
   // Schedule the worker with lib_uv
   uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);

--- a/lib/kerberos.cc
+++ b/lib/kerberos.cc
@@ -236,6 +236,10 @@ NAN_METHOD(Kerberos::AuthGSSClientStep) {
   Local<Object> object = args[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
 
+  if (!kerberos_context->IsClientInstance()) {
+      return NanThrowError("GSS context is not a client instance");
+  }
+
   int callbackArg = 1;
 
   // If we have a challenge string
@@ -331,6 +335,10 @@ NAN_METHOD(Kerberos::AuthGSSClientUnwrap) {
   // Let's unpack the parameters
   Local<Object> object = args[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
+
+  if (!kerberos_context->IsClientInstance()) {
+      return NanThrowError("GSS context is not a client instance");
+  }
 
   // If we have a challenge string
   if(args.Length() == 3) {
@@ -428,6 +436,10 @@ NAN_METHOD(Kerberos::AuthGSSClientWrap) {
   Local<Object> object = args[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
 
+  if (!kerberos_context->IsClientInstance()) {
+      return NanThrowError("GSS context is not a client instance");
+  }
+
   // Unpack the challenge string
   Local<String> challenge = args[1]->ToString();
   // Convert uri string to c-string
@@ -517,6 +529,10 @@ NAN_METHOD(Kerberos::AuthGSSClientClean) {
   // Let's unpack the kerberos context
   Local<Object> object = args[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
+
+  if (!kerberos_context->IsClientInstance()) {
+      return NanThrowError("GSS context is not a client instance");
+  }
 
   // Allocate a structure
   AuthGSSClientCleanCall *call = (AuthGSSClientCleanCall *)calloc(1, sizeof(AuthGSSClientCleanCall));
@@ -667,6 +683,10 @@ NAN_METHOD(Kerberos::AuthGSSServerClean) {
   Local<Object> object = args[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
 
+  if (!kerberos_context->IsServerInstance()) {
+      return NanThrowError("GSS context is not a server instance");
+  }
+
   // Allocate a structure
   AuthGSSServerCleanCall *call = (AuthGSSServerCleanCall *)calloc(1, sizeof(AuthGSSServerCleanCall));
   if(call == NULL) die("Memory allocation failed");
@@ -750,6 +770,10 @@ NAN_METHOD(Kerberos::AuthGSSServerStep) {
   // Let's unpack the parameters
   Local<Object> object = args[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
+
+  if (!kerberos_context->IsServerInstance()) {
+      return NanThrowError("GSS context is not a server instance");
+  }
 
   // Unpack the auth_data string
   Local<String> auth_data = args[1]->ToString();

--- a/lib/kerberos.h
+++ b/lib/kerberos.h
@@ -35,6 +35,9 @@ public:
   static NAN_METHOD(AuthGSSClientUnwrap);
   static NAN_METHOD(AuthGSSClientWrap);
   static NAN_METHOD(AuthGSSClientClean);
+  static NAN_METHOD(AuthGSSServerInit);
+  static NAN_METHOD(AuthGSSServerClean);
+  static NAN_METHOD(AuthGSSServerStep);
 
 private:
   static NAN_METHOD(New);

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -54,9 +54,10 @@ Kerberos.prototype.authGSSServerClean = function(context, callback) {
   return this._native_kerberos.authGSSServerClean(context, callback);
 };
 
-// authData should be the base64 encoded authentication data passed, e.g., in
-// the Authorization header (without the leading "Negotiate " string) during
-// SPNEGO authentication
+// authData should be the base64 encoded authentication data obtained
+// from client, e.g., in the Authorization header (without the leading 
+// "Negotiate " string) during SPNEGO authentication.  The authenticated user 
+// is available in context.username after successful authentication.
 Kerberos.prototype.authGSSServerStep = function(context, authData, callback) {
   return this._native_kerberos.authGSSServerStep(context, authData, callback);
 };

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -41,19 +41,14 @@ Kerberos.prototype.authGSSClientClean = function(context, callback) {
 }
 
 Kerberos.prototype.authGSSServerInit = function(service, callback) {
-	  return this._native_kerberos.authGSSServerInit(service, callback);
+  return this._native_kerberos.authGSSServerInit(service, callback);
 };
 
 Kerberos.prototype.authGSSServerClean = function(context, callback) {
-	  return this._native_kerberos.authGSSServerClean(context, callback);
+  return this._native_kerberos.authGSSServerClean(context, callback);
 };
 
 Kerberos.prototype.authGSSServerStep = function(context, challenge, callback) {
-  if(typeof challenge == 'function') {
-    callback = challenge;
-    challenge = '';
-  }
-
   return this._native_kerberos.authGSSServerStep(context, challenge, callback);
 };
 

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -54,8 +54,11 @@ Kerberos.prototype.authGSSServerClean = function(context, callback) {
   return this._native_kerberos.authGSSServerClean(context, callback);
 };
 
-Kerberos.prototype.authGSSServerStep = function(context, challenge, callback) {
-  return this._native_kerberos.authGSSServerStep(context, challenge, callback);
+// authData should be the base64 encoded authentication data passed, e.g., in
+// the Authorization header (without the leading "Negotiate " string) during
+// SPNEGO authentication
+Kerberos.prototype.authGSSServerStep = function(context, authData, callback) {
+  return this._native_kerberos.authGSSServerStep(context, authData, callback);
 };
 
 Kerberos.prototype.acquireAlternateCredentials = function(user_name, password, domain) {

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -5,10 +5,20 @@ var Kerberos = function() {
   this._native_kerberos = new KerberosNative(); 
 }
 
+// callback takes two arguments, an error string if defined and a new context
+// uri should be given as service@host.  Services are not always defined
+// in a straightforward way.  Use 'HTTP' for SPNEGO / Negotiate authentication. 
 Kerberos.prototype.authGSSClientInit = function(uri, flags, callback) {
   return this._native_kerberos.authGSSClientInit(uri, flags, callback);
 }
 
+// This will obtain credentials using a credentials cache. To override the default
+// location (posible /tmp/krb5cc_nnnnnn, where nnnn is your numeric uid) use 
+// the environment variable KRB5CNAME. 
+// The credentials (suitable for using in an 'Authenticate: ' header, when prefixed
+// with 'Negotiate ') will be available as context.response inside the callback
+// if no error is indicated.
+// callback takes one argument, an error string if defined
 Kerberos.prototype.authGSSClientStep = function(context, challenge, callback) {
   if(typeof challenge == 'function') {
     callback = challenge;
@@ -36,6 +46,8 @@ Kerberos.prototype.authGSSClientWrap = function(context, challenge, user_name, c
   return this._native_kerberos.authGSSClientWrap(context, challenge, user_name, callback);
 }
 
+// free memory used by a context created using authGSSClientInit.
+// callback takes one argument, an error string if defined.
 Kerberos.prototype.authGSSClientClean = function(context, callback) {
   return this._native_kerberos.authGSSClientClean(context, callback);
 }
@@ -46,10 +58,12 @@ Kerberos.prototype.authGSSClientClean = function(context, callback) {
 // The service name should be in the form service, or service@host.name
 // e.g. for HTTP, use "HTTP" or "HTTP@my.host.name". See gss_import_name
 // for GSS_C_NT_HOSTBASED_SERVICE.
+// callback takes two arguments, an error string if defined and a new context
 Kerberos.prototype.authGSSServerInit = function(service, callback) {
   return this._native_kerberos.authGSSServerInit(service, callback);
 };
 
+//callback takes one argument, an error string if defined.
 Kerberos.prototype.authGSSServerClean = function(context, callback) {
   return this._native_kerberos.authGSSServerClean(context, callback);
 };
@@ -58,6 +72,7 @@ Kerberos.prototype.authGSSServerClean = function(context, callback) {
 // from client, e.g., in the Authorization header (without the leading 
 // "Negotiate " string) during SPNEGO authentication.  The authenticated user 
 // is available in context.username after successful authentication.
+// callback takes one argument, an error string if defined.
 Kerberos.prototype.authGSSServerStep = function(context, authData, callback) {
   return this._native_kerberos.authGSSServerStep(context, authData, callback);
 };

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -40,6 +40,23 @@ Kerberos.prototype.authGSSClientClean = function(context, callback) {
   return this._native_kerberos.authGSSClientClean(context, callback);
 }
 
+Kerberos.prototype.authGSSServerInit = function(service, callback) {
+	  return this._native_kerberos.authGSSServerInit(service, callback);
+};
+
+Kerberos.prototype.authGSSServerClean = function(context, callback) {
+	  return this._native_kerberos.authGSSServerClean(context, callback);
+};
+
+Kerberos.prototype.authGSSServerStep = function(context, challenge, callback) {
+  if(typeof challenge == 'function') {
+    callback = challenge;
+    challenge = '';
+  }
+
+  return this._native_kerberos.authGSSServerStep(context, challenge, callback);
+};
+
 Kerberos.prototype.acquireAlternateCredentials = function(user_name, password, domain) {
   return this._native_kerberos.acquireAlternateCredentials(user_name, password, domain); 
 }

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -40,6 +40,12 @@ Kerberos.prototype.authGSSClientClean = function(context, callback) {
   return this._native_kerberos.authGSSClientClean(context, callback);
 }
 
+// The server will obtain credentials using a keytab.  To override the 
+// default location (probably /etc/krb5.keytab) set the KRB5_KTNAME
+// environment variable.
+// The service name should be in the form service, or service@host.name
+// e.g. for HTTP, use "HTTP" or "HTTP@my.host.name". See gss_import_name
+// for GSS_C_NT_HOSTBASED_SERVICE.
 Kerberos.prototype.authGSSServerInit = function(service, callback) {
   return this._native_kerberos.authGSSServerInit(service, callback);
 };

--- a/lib/kerberos_context.cc
+++ b/lib/kerberos_context.cc
@@ -41,6 +41,12 @@ void KerberosContext::Initialize(v8::Handle<v8::Object> target) {
   // Getter for the response
   proto->SetAccessor(NanNew<String>("response"), KerberosContext::ResponseGetter);
 
+  // Getter for the username - server side only
+  proto->SetAccessor(NanNew<String>("username"), KerberosContext::UsernameGetter);
+
+  // Getter for the targetname - server side only
+  proto->SetAccessor(NanNew<String>("targetname"), KerberosContext::TargetnameGetter);
+
   // Set persistent
   NanAssignPersistent(constructor_template, t);
 
@@ -48,7 +54,7 @@ void KerberosContext::Initialize(v8::Handle<v8::Object> target) {
   target->ForceSet(NanNew<String>("KerberosContext"), t->GetFunction());
 }
 
-//
+
 // Response Setter / Getter
 NAN_GETTER(KerberosContext::ResponseGetter) {
   NanScope();
@@ -71,6 +77,44 @@ NAN_GETTER(KerberosContext::ResponseGetter) {
   } else {
     // Return the response
     NanReturnValue(NanNew<String>(response));
+  }
+}
+
+// username Getter - server side only
+NAN_GETTER(KerberosContext::UsernameGetter) {
+  NanScope();
+
+  // Unpack the object
+  KerberosContext *context = ObjectWrap::Unwrap<KerberosContext>(args.This());
+
+  gss_server_state *server_state = context->server_state;
+
+  // the non-NULL provides a response string, which could be NULL, otherwise NULL.
+  char *username = server_state != NULL ? server_state->username : NULL;
+
+  if(username == NULL) {
+    NanReturnValue(NanNull());
+  } else {
+    NanReturnValue(NanNew<String>(username));
+  }
+}
+
+// targetname Getter - server side only
+NAN_GETTER(KerberosContext::TargetnameGetter) {
+  NanScope();
+
+  // Unpack the object
+  KerberosContext *context = ObjectWrap::Unwrap<KerberosContext>(args.This());
+
+  gss_server_state *server_state = context->server_state;
+
+  // the non-NULL provides a response string, which could be NULL, otherwise NULL.
+  char *targetname = server_state != NULL ? server_state->targetname : NULL;
+
+  if(targetname == NULL) {
+    NanReturnValue(NanNull());
+  } else {
+    NanReturnValue(NanNew<String>(targetname));
   }
 }
 

--- a/lib/kerberos_context.cc
+++ b/lib/kerberos_context.cc
@@ -41,7 +41,7 @@ void KerberosContext::Initialize(v8::Handle<v8::Object> target) {
   // Getter for the response
   proto->SetAccessor(NanNew<String>("response"), KerberosContext::ResponseGetter);
 
-  // Getter for the username - server side only
+  // Getter for the username
   proto->SetAccessor(NanNew<String>("username"), KerberosContext::UsernameGetter);
 
   // Getter for the targetname - server side only

--- a/lib/kerberos_context.cc
+++ b/lib/kerberos_context.cc
@@ -90,7 +90,7 @@ NAN_GETTER(KerberosContext::UsernameGetter) {
   gss_client_state *client_state = context->state;
   gss_server_state *server_state = context->server_state;
 
-  // the non-NULL provides a response string, which could be NULL, otherwise NULL.
+  // If client state is in use, take response from there, otherwise from server
   char *username = client_state != NULL ? client_state->username :
 	  server_state != NULL ? server_state->username : NULL;
 
@@ -110,7 +110,6 @@ NAN_GETTER(KerberosContext::TargetnameGetter) {
 
   gss_server_state *server_state = context->server_state;
 
-  // the non-NULL provides a response string, which could be NULL, otherwise NULL.
   char *targetname = server_state != NULL ? server_state->targetname : NULL;
 
   if(targetname == NULL) {

--- a/lib/kerberos_context.cc
+++ b/lib/kerberos_context.cc
@@ -3,6 +3,8 @@
 Persistent<FunctionTemplate> KerberosContext::constructor_template;
 
 KerberosContext::KerberosContext() : ObjectWrap() {
+    state = NULL;
+    server_state = NULL;
 }
 
 KerberosContext::~KerberosContext() {

--- a/lib/kerberos_context.cc
+++ b/lib/kerberos_context.cc
@@ -80,17 +80,19 @@ NAN_GETTER(KerberosContext::ResponseGetter) {
   }
 }
 
-// username Getter - server side only
+// username Getter
 NAN_GETTER(KerberosContext::UsernameGetter) {
   NanScope();
 
   // Unpack the object
   KerberosContext *context = ObjectWrap::Unwrap<KerberosContext>(args.This());
 
+  gss_client_state *client_state = context->state;
   gss_server_state *server_state = context->server_state;
 
   // the non-NULL provides a response string, which could be NULL, otherwise NULL.
-  char *username = server_state != NULL ? server_state->username : NULL;
+  char *username = client_state != NULL ? client_state->username :
+	  server_state != NULL ? server_state->username : NULL;
 
   if(username == NULL) {
     NanReturnValue(NanNull());
@@ -117,12 +119,3 @@ NAN_GETTER(KerberosContext::TargetnameGetter) {
     NanReturnValue(NanNew<String>(targetname));
   }
 }
-
-
-
-
-
-
-
-
-

--- a/lib/kerberos_context.cc
+++ b/lib/kerberos_context.cc
@@ -52,18 +52,25 @@ void KerberosContext::Initialize(v8::Handle<v8::Object> target) {
 // Response Setter / Getter
 NAN_GETTER(KerberosContext::ResponseGetter) {
   NanScope();
-  gss_client_state *state;
+  gss_client_state *client_state;
+  gss_server_state *server_state;
 
   // Unpack the object
   KerberosContext *context = ObjectWrap::Unwrap<KerberosContext>(args.This());
-  // Let's grab the response
-  state = context->state;
-  // No state no response
-  if(state == NULL || state->response == NULL) {
+
+  // Let's grab the two possible responses
+  client_state = context->state;
+  server_state = context->server_state;
+
+  // the non-NULL provides a response string, which could be NULL, otherwise NULL.
+  char *response = client_state != NULL ? client_state->response :
+	  server_state != NULL ? server_state->response : NULL;
+
+  if(response == NULL) {
     NanReturnValue(NanNull());
   } else {
     // Return the response
-    NanReturnValue(NanNew<String>(state->response));
+    NanReturnValue(NanNew<String>(response));
   }
 }
 

--- a/lib/kerberos_context.cc
+++ b/lib/kerberos_context.cc
@@ -64,11 +64,11 @@ NAN_GETTER(KerberosContext::ResponseGetter) {
   // Unpack the object
   KerberosContext *context = ObjectWrap::Unwrap<KerberosContext>(args.This());
 
-  // Let's grab the two possible responses
+  // Response could come from client or server state...
   client_state = context->state;
   server_state = context->server_state;
 
-  // the non-NULL provides a response string, which could be NULL, otherwise NULL.
+  // If client state is in use, take response from there, otherwise from server
   char *response = client_state != NULL ? client_state->response :
 	  server_state != NULL ? server_state->response : NULL;
 

--- a/lib/kerberos_context.h
+++ b/lib/kerberos_context.h
@@ -38,8 +38,11 @@ public:
   // Public constructor
   static KerberosContext* New();
 
-  // Handle to the kerberos context
+  // Handle to the kerberos client context
   gss_client_state *state;
+
+  // Handle to the kerberos server context
+  gss_server_state *server_state;
 
 private:
   static NAN_METHOD(New);

--- a/lib/kerberos_context.h
+++ b/lib/kerberos_context.h
@@ -46,6 +46,10 @@ public:
 
 private:
   static NAN_METHOD(New);
+  // in either client state or server state
   static NAN_GETTER(ResponseGetter);
+  // these are only in the "server_state"
+  static NAN_GETTER(UsernameGetter);
+  static NAN_GETTER(TargetnameGetter);
 };
 #endif

--- a/lib/kerberos_context.h
+++ b/lib/kerberos_context.h
@@ -46,10 +46,10 @@ public:
 
 private:
   static NAN_METHOD(New);
-  // in either client state or server state
+  // In either client state or server state
   static NAN_GETTER(ResponseGetter);
-  // these are only in the "server_state"
   static NAN_GETTER(UsernameGetter);
+  // Only in the "server_state"
   static NAN_GETTER(TargetnameGetter);
 };
 #endif

--- a/lib/kerberos_context.h
+++ b/lib/kerberos_context.h
@@ -29,6 +29,14 @@ public:
     return NanNew(constructor_template)->HasInstance(obj);
   };
 
+  inline bool IsClientInstance() {
+      return state != NULL;
+  }
+
+  inline bool IsServerInstance() {
+      return server_state != NULL;
+  }
+
   // Constructor used for creating new Kerberos objects from C++
   static Persistent<FunctionTemplate> constructor_template;
 

--- a/lib/kerberosgss.c
+++ b/lib/kerberosgss.c
@@ -434,7 +434,7 @@ gss_client_response *authenticate_gss_server_init(const char *service, gss_serve
     state->username = NULL;
     state->targetname = NULL;
     state->response = NULL;
-    
+
     // Server name may be empty which means we aren't going to create our own creds
     size_t service_len = strlen(service);
     if (service_len != 0)

--- a/lib/kerberosgss.c
+++ b/lib/kerberosgss.c
@@ -573,7 +573,7 @@ gss_client_response *authenticate_gss_server_step(gss_server_state *state, const
     // Grab the server response to send back to the client
     if (output_token.length)
     {
-        state->response = base64_encode((const unsigned char *)output_token.value, output_token.length);;
+        state->response = base64_encode((const unsigned char *)output_token.value, output_token.length);
         maj_stat = gss_release_buffer(&min_stat, &output_token);
     }
     

--- a/lib/kerberosgss.c
+++ b/lib/kerberosgss.c
@@ -517,7 +517,7 @@ gss_client_response *authenticate_gss_server_clean(gss_server_state *state)
     return response;
 }
 
-gss_client_response *authenticate_gss_server_step(gss_server_state *state, const char *challenge)
+gss_client_response *authenticate_gss_server_step(gss_server_state *state, const char *auth_data)
 {
     OM_uint32 maj_stat;
     OM_uint32 min_stat;
@@ -533,18 +533,17 @@ gss_client_response *authenticate_gss_server_step(gss_server_state *state, const
         state->response = NULL;
     }
     
-    // If there is a challenge (data from the server) we need to give it to GSS
-    if (challenge && *challenge)
+    if (auth_data && *auth_data)
     {
         int len;
-        input_token.value = base64_decode(challenge, &len);
+        input_token.value = base64_decode(auth_data, &len);
         input_token.length = len;
     }
     else
     {
 	response = calloc(1, sizeof(gss_client_response));
 	if(response == NULL) die1("Memory allocation failed");
-        response->message = strdup("No challenge parameter in request from client");
+        response->message = strdup("No auth_data value in request from client");
         response->return_code = AUTH_GSS_ERROR;
         goto end;
     }

--- a/lib/kerberosgss.h
+++ b/lib/kerberosgss.h
@@ -62,9 +62,9 @@ gss_client_response *authenticate_gss_client_step(gss_client_state *state, const
 gss_client_response *authenticate_gss_client_unwrap(gss_client_state* state, const char* challenge);
 gss_client_response *authenticate_gss_client_wrap(gss_client_state* state, const char* challenge, const char* user);
 
-int authenticate_gss_server_init(const char* service, gss_server_state* state);
-int authenticate_gss_server_clean(gss_server_state *state);
-// int authenticate_gss_server_step(gss_server_state *state, const char *challenge);
+gss_client_response *authenticate_gss_server_init(const char* service, gss_server_state* state);
+gss_client_response *authenticate_gss_server_clean(gss_server_state *state);
+gss_client_response *authenticate_gss_server_step(gss_server_state *state, const char *challenge);
 
 gss_client_response *gss_error(OM_uint32 err_maj, OM_uint32 err_min);
 #endif

--- a/lib/kerberosgss.h
+++ b/lib/kerberosgss.h
@@ -66,5 +66,4 @@ gss_client_response *authenticate_gss_server_init(const char* service, gss_serve
 gss_client_response *authenticate_gss_server_clean(gss_server_state *state);
 gss_client_response *authenticate_gss_server_step(gss_server_state *state, const char *challenge);
 
-gss_client_response *gss_error(OM_uint32 err_maj, OM_uint32 err_min);
 #endif


### PR DESCRIPTION
This set of commits implements the three methods (which were already present in the lowlevel code):

authGSSServerInit
authGSSServerClean
authGSSServerStep

With these three methods, it has been verified that server side "Negotiate" authentication can be implemented for HTTP, for example using a passport plugin in an Express app. I have also verified that client side Negotiate also works using this code.

Most of the work was just "cloning" the work already done for the authGSSClient\* calls.

There were a few typos and minor fixes to the existing code.

If you would like any kind of squashing of these commits or spliting or making separate pull requests, that would be fine, just let me know and I can accommodate.
