### PR TITLE
implement S4U (S4U2Proxy & S4U2Self)

### DIFF
--- a/lib/kerberos.cc
+++ b/lib/kerberos.cc
@@ -593,15 +593,15 @@ static Local<Value> _map_authGSSServerInit(Worker *worker) {
 // Server Initialize method
 NAN_METHOD(Kerberos::AuthGSSServerInit) {
   // Ensure valid call
-  if(args.Length() != 4) return Nan::ThrowError("Requires a service string, constrained delegation boolean, a username string (or NULL) for S4U2Self protocol transition and a callback function");
+  if(info.Length() != 4) return Nan::ThrowError("Requires a service string, constrained delegation boolean, a username string (or NULL) for S4U2Self protocol transition and a callback function");
 
-  if(!args[0]->IsString() ||
-	  !args[1]->IsBoolean() ||
-	  !(args[2]->IsString() || args[2]->IsNull()) ||
-	  !args[3]->IsFunction()
+  if(!info[0]->IsString() ||
+	  !info[1]->IsBoolean() ||
+	  !(info[2]->IsString() || info[2]->IsNull()) ||
+	  !info[3]->IsFunction()
      ) return Nan::ThrowError("Requires a service string, constrained delegation boolean, a username string (or NULL) for S4U2Self protocol transition and  a callback function");
 
-  if (!args[1]->BooleanValue() && !args[2]->IsNull()) return Nan::ThrowError("S4U2Self only possible when constrained delegation is enabled");
+  if (!info[1]->BooleanValue() && !info[2]->IsNull()) return Nan::ThrowError("S4U2Self only possible when constrained delegation is enabled");
 
   // Allocate a structure
   AuthGSSServerInitCall *call = (AuthGSSServerInitCall *)calloc(1, sizeof(AuthGSSServerInitCall));
@@ -617,15 +617,15 @@ NAN_METHOD(Kerberos::AuthGSSServerInit) {
 
   call->service = service_str;
 
-  call->constrained_delegation = args[1]->BooleanValue();
+  call->constrained_delegation = info[1]->BooleanValue();
 
-  if (args[2]->IsNull())
+  if (info[2]->IsNull())
   {
       call->username = NULL;
   }
   else
   {
-      Local<String> tmpString = args[2]->ToString();
+      Local<String> tmpString = info[2]->ToString();
 
       char *tmpCstr = (char *)calloc(tmpString->Utf8Length() + 1, sizeof(char));
       if(tmpCstr == NULL) die("Memory allocation failed");

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -58,9 +58,21 @@ Kerberos.prototype.authGSSClientClean = function(context, callback) {
 // The service name should be in the form service, or service@host.name
 // e.g. for HTTP, use "HTTP" or "HTTP@my.host.name". See gss_import_name
 // for GSS_C_NT_HOSTBASED_SERVICE.
+//
+// a boolean turns on "constrained_delegation". this enables acquisition of S4U2Proxy 
+// credentials which will be stored in a credentials cache during the authGSSServerStep
+// method. this parameter is optional.
+//
 // callback takes two arguments, an error string if defined and a new context
-Kerberos.prototype.authGSSServerInit = function(service, callback) {
-  return this._native_kerberos.authGSSServerInit(service, callback);
+Kerberos.prototype.authGSSServerInit = function(service, constrained_delegation, callback) {
+  if(typeof constrained_delegation == 'function') {
+	  callback = constrained_delegation;
+	  constrained_delegation = false;
+  }
+
+  constrained_delegation = !!constrained_delegation;
+  
+  return this._native_kerberos.authGSSServerInit(service, constrained_delegation, callback);
 };
 
 //callback takes one argument, an error string if defined.

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -63,16 +63,36 @@ Kerberos.prototype.authGSSClientClean = function(context, callback) {
 // credentials which will be stored in a credentials cache during the authGSSServerStep
 // method. this parameter is optional.
 //
+// when "constrained_delegation" is enabled, a username can (optionally) be provided and
+// S4U2Self protocol transition will be initiated. In this case, we will not
+// require any "auth" data during the authGSSServerStep. This parameter is optional
+// but constrained_delegation MUST be enabled for this to work. When S4U2Self is
+// used, the username will be assumed to have been already authenticated, and no
+// actual authentication will be performed. This is basically a way to "bootstrap"
+// kerberos credentials (which can then be delegated with S4U2Proxy) for a user
+// authenticated externally.
+//
 // callback takes two arguments, an error string if defined and a new context
-Kerberos.prototype.authGSSServerInit = function(service, constrained_delegation, callback) {
-  if(typeof constrained_delegation == 'function') {
+//
+Kerberos.prototype.authGSSServerInit = function(service, constrained_delegation, username, callback) {
+  if(typeof(constrained_delegation) === 'function') {
 	  callback = constrained_delegation;
 	  constrained_delegation = false;
+	  username = null;
+  }
+
+  if (typeof(constrained_delegation) === 'string') {
+	  throw new Error("S4U2Self protocol transation is not possible without enabling constrained delegation");
+  }
+
+  if (typeof(username) === 'function') {
+	  callback = username;
+	  username = null;
   }
 
   constrained_delegation = !!constrained_delegation;
   
-  return this._native_kerberos.authGSSServerInit(service, constrained_delegation, callback);
+  return this._native_kerberos.authGSSServerInit(service, constrained_delegation, username, callback);
 };
 
 //callback takes one argument, an error string if defined.
@@ -85,6 +105,10 @@ Kerberos.prototype.authGSSServerClean = function(context, callback) {
 // "Negotiate " string) during SPNEGO authentication.  The authenticated user 
 // is available in context.username after successful authentication.
 // callback takes one argument, an error string if defined.
+//
+// Note: when S4U2Self protocol transition was requested in the authGSSServerInit
+// no actual authentication will be performed and authData will be ignored.
+//
 Kerberos.prototype.authGSSServerStep = function(context, authData, callback) {
   return this._native_kerberos.authGSSServerStep(context, authData, callback);
 };

--- a/lib/kerberos_context.cc
+++ b/lib/kerberos_context.cc
@@ -47,7 +47,7 @@ void KerberosContext::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) 
   // Getter for the targetname - server side only
   Nan::SetAccessor(proto, Nan::New<String>("targetname").ToLocalChecked(), KerberosContext::TargetnameGetter);
 
-  proto->SetAccessor(NanNew<String>("delegatedCredentialsCache"), KerberosContext::DelegatedCredentialsCacheGetter);
+  Nan::SetAccessor(proto, Nan::New<String>("delegatedCredentialsCache").ToLocalChecked(), KerberosContext::DelegatedCredentialsCacheGetter);
 
   // Set persistent
   constructor_template.Reset(t);
@@ -119,18 +119,16 @@ NAN_GETTER(KerberosContext::TargetnameGetter) {
 
 // targetname Getter - server side only
 NAN_GETTER(KerberosContext::DelegatedCredentialsCacheGetter) {
-  NanScope();
-
   // Unpack the object
-  KerberosContext *context = ObjectWrap::Unwrap<KerberosContext>(args.This());
+  KerberosContext *context = Nan::ObjectWrap::Unwrap<KerberosContext>(info.This());
 
   gss_server_state *server_state = context->server_state;
 
   char *delegated_credentials_cache = server_state != NULL ? server_state->delegated_credentials_cache : NULL;
 
   if(delegated_credentials_cache == NULL) {
-    NanReturnValue(NanNull());
+    info.GetReturnValue().Set(Nan::Null());
   } else {
-    NanReturnValue(NanNew<String>(delegated_credentials_cache));
+    info.GetReturnValue().Set(Nan::New<String>(delegated_credentials_cache).ToLocalChecked());
   }
 }

--- a/lib/kerberos_context.cc
+++ b/lib/kerberos_context.cc
@@ -47,6 +47,8 @@ void KerberosContext::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) 
   // Getter for the targetname - server side only
   Nan::SetAccessor(proto, Nan::New<String>("targetname").ToLocalChecked(), KerberosContext::TargetnameGetter);
 
+  proto->SetAccessor(NanNew<String>("delegatedCredentialsCache"), KerberosContext::DelegatedCredentialsCacheGetter);
+
   // Set persistent
   constructor_template.Reset(t);
  // NanAssignPersistent(constructor_template, t);
@@ -112,5 +114,23 @@ NAN_GETTER(KerberosContext::TargetnameGetter) {
     info.GetReturnValue().Set(Nan::Null());
   } else {
     info.GetReturnValue().Set(Nan::New<String>(targetname).ToLocalChecked());
+  }
+}
+
+// targetname Getter - server side only
+NAN_GETTER(KerberosContext::DelegatedCredentialsCacheGetter) {
+  NanScope();
+
+  // Unpack the object
+  KerberosContext *context = ObjectWrap::Unwrap<KerberosContext>(args.This());
+
+  gss_server_state *server_state = context->server_state;
+
+  char *delegated_credentials_cache = server_state != NULL ? server_state->delegated_credentials_cache : NULL;
+
+  if(delegated_credentials_cache == NULL) {
+    NanReturnValue(NanNull());
+  } else {
+    NanReturnValue(NanNew<String>(delegated_credentials_cache));
   }
 }

--- a/lib/kerberos_context.h
+++ b/lib/kerberos_context.h
@@ -59,5 +59,6 @@ private:
   static NAN_GETTER(UsernameGetter);
   // Only in the "server_state"
   static NAN_GETTER(TargetnameGetter);
+  static NAN_GETTER(DelegatedCredentialsCacheGetter);
 };
 #endif

--- a/lib/kerberosgss.c
+++ b/lib/kerberosgss.c
@@ -30,6 +30,8 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <stdarg.h>
+#include <unistd.h>
+#include <krb5.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -494,7 +496,7 @@ gss_client_response *authenticate_gss_server_init(const char *service, bool cons
 	gss_name_t gss_username;
 
 	name_token.length = strlen(username);
-	name_token.value = username;
+	name_token.value = (char *)username;
 
 	maj_stat = gss_import_name(&min_stat, &name_token, GSS_C_NT_USER_NAME, &gss_username);
 	if (GSS_ERROR(maj_stat))
@@ -885,13 +887,13 @@ gss_client_response *gss_error(const char *func, const char *op, OM_uint32 err_m
 static gss_client_response *krb5_ctx_error(krb5_context context, krb5_error_code problem)
 {
     gss_client_response *response = NULL;
-    char *error_text = krb5_get_err_text(context, problem);
+    const char *error_text = krb5_get_error_message(context, problem);
     response = calloc(1, sizeof(gss_client_response));
     if(response == NULL) die1("Memory allocation failed");
     response->message = strdup(error_text);
     // TODO: something other than AUTH_GSS_ERROR? AUTH_KRB5_ERROR ?
     response->return_code = AUTH_GSS_ERROR;
-    krb5_free_error_string(context, error_text);
+    krb5_free_error_message(context, error_text);
     return response;
 }
 

--- a/lib/kerberosgss.h
+++ b/lib/kerberosgss.h
@@ -66,7 +66,7 @@ gss_client_response *authenticate_gss_client_step(gss_client_state *state, const
 gss_client_response *authenticate_gss_client_unwrap(gss_client_state* state, const char* challenge);
 gss_client_response *authenticate_gss_client_wrap(gss_client_state* state, const char* challenge, const char* user);
 
-gss_client_response *authenticate_gss_server_init(const char* service, bool constrained_delegation, gss_server_state* state);
+gss_client_response *authenticate_gss_server_init(const char* service, bool constrained_delegation, const char *username, gss_server_state* state);
 gss_client_response *authenticate_gss_server_clean(gss_server_state *state);
 gss_client_response *authenticate_gss_server_step(gss_server_state *state, const char *challenge);
 

--- a/lib/kerberosgss.h
+++ b/lib/kerberosgss.h
@@ -16,6 +16,8 @@
 #ifndef KERBEROS_GSS_H
 #define KERBEROS_GSS_H
 
+#include <stdbool.h>
+
 #include <gssapi/gssapi.h>
 #include <gssapi/gssapi_generic.h>
 #include <gssapi/gssapi_krb5.h>
@@ -52,6 +54,8 @@ typedef struct {
   char*            username;
   char*            targetname;
   char*            response;
+  bool		   constrained_delegation;
+  char*		   delegated_credentials_cache;
 } gss_server_state;
 
 // char* server_principal_details(const char* service, const char* hostname);
@@ -62,7 +66,7 @@ gss_client_response *authenticate_gss_client_step(gss_client_state *state, const
 gss_client_response *authenticate_gss_client_unwrap(gss_client_state* state, const char* challenge);
 gss_client_response *authenticate_gss_client_wrap(gss_client_state* state, const char* challenge, const char* user);
 
-gss_client_response *authenticate_gss_server_init(const char* service, gss_server_state* state);
+gss_client_response *authenticate_gss_server_init(const char* service, bool constrained_delegation, gss_server_state* state);
 gss_client_response *authenticate_gss_server_clean(gss_server_state *state);
 gss_client_response *authenticate_gss_server_step(gss_server_state *state, const char *challenge);
 


### PR DESCRIPTION
This pull request implements S4U2Proxy (constrained delegation) and S4U2Self (protocol transition) in the server side functions.  Behavior is optional.

No client side methods are touched at all.

There is one other feature that _does_ touch client code that I will submit a separate pull request for.  (I previously had mentioned two features but I have rolled both of the server side modifications into this pull request).
