### PR TITLE
More updates for NAN 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: node_js
+node_js:
+  - "0.8"
+  - "0.10"
+  - "0.12"
+  - "iojs-v1.8.4"
+  - "iojs-v2.5.0"
+  - "iojs-v3.3.0"
+  - "4"
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+before_install:
+  - '[ "${TRAVIS_NODE_VERSION}" != "0.8" ] || npm install -g npm@1.4.28'
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
+  - $CXX --version
+  - npm explore npm -g -- npm install node-gyp@latest

--- a/lib/kerberos.cc
+++ b/lib/kerberos.cc
@@ -237,7 +237,7 @@ NAN_METHOD(Kerberos::AuthGSSClientStep) {
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
 
   if (!kerberos_context->IsClientInstance()) {
-      return NanThrowError("GSS context is not a client instance");
+      return Nan::ThrowError("GSS context is not a client instance");
   }
 
   int callbackArg = 1;
@@ -263,7 +263,7 @@ NAN_METHOD(Kerberos::AuthGSSClientStep) {
 
   // Unpack the callback
   Local<Function> callbackHandle = Local<Function>::Cast(info[callbackArg]);
-  NanCallback *callback = new Nan::Callback(callbackHandle);
+  Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   // Let's allocate some space
   Worker *worker = new Worker();
@@ -328,7 +328,7 @@ NAN_METHOD(Kerberos::AuthGSSClientUnwrap) {
   // Ensure valid call
     if(info.Length() != 2 && info.Length() != 3) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
     if(info.Length() == 2 && (!KerberosContext::HasInstance(info[0]) || !info[1]->IsFunction())) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
-    if(info.Length() == 3 && (!KerberosContext::HasInstance(args[0]) || !info[1]->IsString() || !args[2]->IsFunction())) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
+    if(info.Length() == 3 && (!KerberosContext::HasInstance(info[0]) || !info[1]->IsString() || !info[2]->IsFunction())) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
 
   // Challenge string
   char *challenge_str = NULL;
@@ -337,7 +337,7 @@ NAN_METHOD(Kerberos::AuthGSSClientUnwrap) {
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
 
   if (!kerberos_context->IsClientInstance()) {
-      return NanThrowError("GSS context is not a client instance");
+      return Nan::ThrowError("GSS context is not a client instance");
   }
 
   // If we have a challenge string
@@ -424,7 +424,7 @@ NAN_METHOD(Kerberos::AuthGSSClientWrap) {
 
   // Ensure valid call
     if(info.Length() != 3 && info.Length() != 4) return Nan::ThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
-    if(info.Length() == 3 && (!KerberosContext::HasInstance(info[0]) || !info[1]->IsString() || !args[2]->IsFunction())) return Nan::ThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
+    if(info.Length() == 3 && (!KerberosContext::HasInstance(info[0]) || !info[1]->IsString() || !info[2]->IsFunction())) return Nan::ThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
     if(info.Length() == 4 && (!KerberosContext::HasInstance(info[0]) || !info[1]->IsString() || !info[2]->IsString() || !info[3]->IsFunction())) return Nan::ThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
 
   // Challenge string
@@ -436,7 +436,7 @@ NAN_METHOD(Kerberos::AuthGSSClientWrap) {
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
 
   if (!kerberos_context->IsClientInstance()) {
-      return NanThrowError("GSS context is not a client instance");
+      return Nan::ThrowError("GSS context is not a client instance");
   }
 
   // Unpack the challenge string
@@ -530,7 +530,7 @@ NAN_METHOD(Kerberos::AuthGSSClientClean) {
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
 
   if (!kerberos_context->IsClientInstance()) {
-      return NanThrowError("GSS context is not a client instance");
+      return Nan::ThrowError("GSS context is not a client instance");
   }
 
   // Allocate a structure
@@ -595,18 +595,18 @@ static void _authGSSServerInit(Worker *worker) {
 static Handle<Value> _map_authGSSServerInit(Worker *worker) {
   KerberosContext *context = KerberosContext::New();
   context->server_state = (gss_server_state *)worker->return_value;
-  return NanObjectWrapHandle(context);
+  return context->handle();
 }
 
 // Server Initialize method
 NAN_METHOD(Kerberos::AuthGSSServerInit) {
-  NanScope();
+  Nan::HandleScope scope;
 
   // Ensure valid call
-  if(args.Length() != 2) return NanThrowError("Requires a service string service and a callback function");
-  if(!args[0]->IsString() || !args[1]->IsFunction()) return NanThrowError("Requires a service string service and a callback function");
+  if(info.Length() != 2) return Nan::ThrowError("Requires a service string service and a callback function");
+  if(!info[0]->IsString() || !info[1]->IsFunction()) return Nan::ThrowError("Requires a service string service and a callback function");
 
-  Local<String> service = args[0]->ToString();
+  Local<String> service = info[0]->ToString();
   // Convert service string to c-string
   char *service_str = (char *)calloc(service->Utf8Length() + 1, sizeof(char));
   if(service_str == NULL) die("Memory allocation failed");
@@ -620,8 +620,8 @@ NAN_METHOD(Kerberos::AuthGSSServerInit) {
   call->service = service_str;
 
   // Unpack the callback
-  Local<Function> callbackHandle = Local<Function>::Cast(args[1]);
-  NanCallback *callback = new NanCallback(callbackHandle);
+  Local<Function> callbackHandle = Local<Function>::Cast(info[1]);
+  Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   // Let's allocate some space
   Worker *worker = new Worker();
@@ -635,7 +635,7 @@ NAN_METHOD(Kerberos::AuthGSSServerInit) {
   // Schedule the worker with lib_uv
   uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
   // Return no value as it's callback based
-  NanReturnValue(NanUndefined());
+  info.GetReturnValue().Set(Nan::Undefined());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -665,25 +665,25 @@ static void _authGSSServerClean(Worker *worker) {
 }
 
 static Handle<Value> _map_authGSSServerClean(Worker *worker) {
-  NanScope();
+  Nan::HandleScope scope;
   // Return the return code
-  return NanNew<Int32>(worker->return_code);
+  return Nan::New<Int32>(worker->return_code);
 }
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSServerClean) {
-  NanScope();
+  Nan::HandleScope scope;
 
   // // Ensure valid call
-  if(args.Length() != 2) return NanThrowError("Requires a GSS context and callback function");
-  if(!KerberosContext::HasInstance(args[0]) || !args[1]->IsFunction()) return NanThrowError("Requires a GSS context and callback function");
+  if(info.Length() != 2) return Nan::ThrowError("Requires a GSS context and callback function");
+  if(!KerberosContext::HasInstance(info[0]) || !info[1]->IsFunction()) return Nan::ThrowError("Requires a GSS context and callback function");
 
   // Let's unpack the kerberos context
-  Local<Object> object = args[0]->ToObject();
+  Local<Object> object = info[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
 
   if (!kerberos_context->IsServerInstance()) {
-      return NanThrowError("GSS context is not a server instance");
+      return Nan::ThrowError("GSS context is not a server instance");
   }
 
   // Allocate a structure
@@ -692,8 +692,8 @@ NAN_METHOD(Kerberos::AuthGSSServerClean) {
   call->context = kerberos_context;
 
   // Unpack the callback
-  Local<Function> callbackHandle = Local<Function>::Cast(args[1]);
-  NanCallback *callback = new NanCallback(callbackHandle);
+  Local<Function> callbackHandle = Local<Function>::Cast(info[1]);
+  Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   // Let's allocate some space
   Worker *worker = new Worker();
@@ -708,7 +708,7 @@ NAN_METHOD(Kerberos::AuthGSSServerClean) {
   uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
 
   // Return no value as it's callback based
-  NanReturnValue(NanUndefined());
+  info.GetReturnValue().Set(Nan::Undefined());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -749,33 +749,33 @@ static void _authGSSServerStep(Worker *worker) {
 }
 
 static Handle<Value> _map_authGSSServerStep(Worker *worker) {
-  NanScope();
+  Nan::HandleScope scope;
   // Return the return code
-  return NanNew<Int32>(worker->return_code);
+  return Nan::New<Int32>(worker->return_code);
 }
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSServerStep) {
-  NanScope();
+  Nan::HandleScope scope;
 
   // Ensure valid call
-  if(args.Length() != 3) return NanThrowError("Requires a GSS context, auth-data string and callback function");
-  if(!KerberosContext::HasInstance(args[0]))  return NanThrowError("1st arg must be a GSS context");
-  if (!args[1]->IsString())  return NanThrowError("2nd arg must be auth-data string");
-  if (!args[2]->IsFunction())  return NanThrowError("3rd arg must be a callback function");
+  if(info.Length() != 3) return Nan::ThrowError("Requires a GSS context, auth-data string and callback function");
+  if(!KerberosContext::HasInstance(info[0]))  return Nan::ThrowError("1st arg must be a GSS context");
+  if (!info[1]->IsString())  return Nan::ThrowError("2nd arg must be auth-data string");
+  if (!info[2]->IsFunction())  return Nan::ThrowError("3rd arg must be a callback function");
 
   // Auth-data string
   char *auth_data_str = NULL;
   // Let's unpack the parameters
-  Local<Object> object = args[0]->ToObject();
+  Local<Object> object = info[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
 
   if (!kerberos_context->IsServerInstance()) {
-      return NanThrowError("GSS context is not a server instance");
+      return Nan::ThrowError("GSS context is not a server instance");
   }
 
   // Unpack the auth_data string
-  Local<String> auth_data = args[1]->ToString();
+  Local<String> auth_data = info[1]->ToString();
   // Convert uri string to c-string
   auth_data_str = (char *)calloc(auth_data->Utf8Length() + 1, sizeof(char));
   if(auth_data_str == NULL) die("Memory allocation failed");
@@ -789,8 +789,8 @@ NAN_METHOD(Kerberos::AuthGSSServerStep) {
   call->auth_data = auth_data_str;
 
   // Unpack the callback
-  Local<Function> callbackHandle = Local<Function>::Cast(args[2]);
-  NanCallback *callback = new NanCallback(callbackHandle);
+  Local<Function> callbackHandle = Local<Function>::Cast(info[2]);
+  Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   // Let's allocate some space
   Worker *worker = new Worker();
@@ -805,7 +805,7 @@ NAN_METHOD(Kerberos::AuthGSSServerStep) {
   uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
 
   // Return no value as it's callback based
-  NanReturnValue(NanUndefined());
+  info.GetReturnValue().Set(Nan::Undefined());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/lib/kerberos.cc
+++ b/lib/kerberos.cc
@@ -159,6 +159,7 @@ NAN_METHOD(Kerberos::AuthGSSClientInit) {
   // Schedule the worker with lib_uv
   uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
   // Return no value as it's callback based
+  info.GetReturnValue().Set(Nan::Undefined());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -253,6 +254,7 @@ NAN_METHOD(Kerberos::AuthGSSClientStep) {
   uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
 
   // Return no value as it's callback based
+  info.GetReturnValue().Set(Nan::Undefined());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -344,7 +346,7 @@ NAN_METHOD(Kerberos::AuthGSSClientUnwrap) {
   uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
 
   // Return no value as it's callback based
-  // return scope.Close(NanUndefined());
+  info.GetReturnValue().Set(Nan::Undefined());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -448,6 +450,7 @@ NAN_METHOD(Kerberos::AuthGSSClientWrap) {
   uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
 
   // Return no value as it's callback based
+  info.GetReturnValue().Set(Nan::Undefined());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -516,6 +519,7 @@ NAN_METHOD(Kerberos::AuthGSSClientClean) {
   uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
 
   // Return no value as it's callback based
+  info.GetReturnValue().Set(Nan::Undefined());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/lib/kerberos.cc
+++ b/lib/kerberos.cc
@@ -845,7 +845,12 @@ void Kerberos::After(uv_work_t* work_req) {
     // // Map the data
     Handle<Value> result = worker->mapper(worker);
     // Set up the callback with a null first
-    Handle<Value> info[2] = { Nan::Null(), result};
+    #if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+      (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+    Local<Value> info[2] = { Nan::Null(), result};
+    #else
+    Local<Value> info[2] = { Nan::Null(), Nan::New<v8::Value>(result)};
+    #endif
 
     // Wrap the callback function call in a TryCatch so that we can call
     // node's FatalException afterwards. This makes it possible to catch

--- a/lib/kerberos.cc
+++ b/lib/kerberos.cc
@@ -62,7 +62,7 @@ Kerberos::Kerberos() : Nan::ObjectWrap() {
 
 Nan::Persistent<FunctionTemplate> Kerberos::constructor_template;
 
-void Kerberos::Initialize(v8::Handle<v8::Object> target) {
+void Kerberos::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   // Grab the scope of the call from Node
   Nan::HandleScope scope;
 
@@ -88,7 +88,6 @@ void Kerberos::Initialize(v8::Handle<v8::Object> target) {
 }
 
 NAN_METHOD(Kerberos::New) {
-  Nan::HandleScope scope;
   // Create a Kerberos instance
   Kerberos *kerberos = new Kerberos();
   // Return the kerberos object
@@ -106,7 +105,7 @@ static void _authGSSClientInit(Worker *worker) {
   // Allocate state
   state = (gss_client_state *)malloc(sizeof(gss_client_state));
   if(state == NULL) die("Memory allocation failed");
-  
+
   // Unpack the parameter data struct
   AuthGSSClientCall *call = (AuthGSSClientCall *)worker->parameters;
   // Start the kerberos client
@@ -130,7 +129,7 @@ static void _authGSSClientInit(Worker *worker) {
   free(response);
 }
 
-static Handle<Value> _map_authGSSClientInit(Worker *worker) {
+static Local<Value> _map_authGSSClientInit(Worker *worker) {
   KerberosContext *context = KerberosContext::New();
   context->state = (gss_client_state *)worker->return_value;
   return context->handle();
@@ -138,8 +137,6 @@ static Handle<Value> _map_authGSSClientInit(Worker *worker) {
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSClientInit) {
-  Nan::HandleScope scope;
-
   // Ensure valid call
     if(info.Length() != 3) return Nan::ThrowError("Requires a service string uri, integer flags and a callback function");
   if(info.Length() == 3 && (!info[0]->IsString() || !info[1]->IsInt32() || !info[2]->IsFunction()))
@@ -215,7 +212,7 @@ static void _authGSSClientStep(Worker *worker) {
   free(response);
 }
 
-static Handle<Value> _map_authGSSClientStep(Worker *worker) {
+static Local<Value> _map_authGSSClientStep(Worker *worker) {
   Nan::HandleScope scope;
   // Return the return code
   return Nan::New<Int32>(worker->return_code);
@@ -223,8 +220,6 @@ static Handle<Value> _map_authGSSClientStep(Worker *worker) {
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSClientStep) {
-  Nan::HandleScope scope;
-
   // Ensure valid call
   if(info.Length() != 2 && info.Length() != 3) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
   if(info.Length() == 2 && (!KerberosContext::HasInstance(info[0]) || !info[1]->IsFunction())) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
@@ -315,7 +310,7 @@ static void _authGSSClientUnwrap(Worker *worker) {
   free(response);
 }
 
-static Handle<Value> _map_authGSSClientUnwrap(Worker *worker) {
+static Local<Value> _map_authGSSClientUnwrap(Worker *worker) {
   Nan::HandleScope scope;
   // Return the return code
   return Nan::New<Int32>(worker->return_code);
@@ -323,8 +318,6 @@ static Handle<Value> _map_authGSSClientUnwrap(Worker *worker) {
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSClientUnwrap) {
-  Nan::HandleScope scope;
-
   // Ensure valid call
     if(info.Length() != 2 && info.Length() != 3) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
     if(info.Length() == 2 && (!KerberosContext::HasInstance(info[0]) || !info[1]->IsFunction())) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
@@ -348,7 +341,7 @@ NAN_METHOD(Kerberos::AuthGSSClientUnwrap) {
     challenge_str = (char *)calloc(challenge->Utf8Length() + 1, sizeof(char));
     if(challenge_str == NULL) die("Memory allocation failed");
     // Write v8 string to c-string
-    challenge->WriteUtf8(challenge_str);    
+    challenge->WriteUtf8(challenge_str);
   }
 
   // Allocate a structure
@@ -386,7 +379,7 @@ static void _authGSSClientWrap(Worker *worker) {
 
   // Unpack the parameter data struct
   AuthGSSClientWrapCall *call = (AuthGSSClientWrapCall *)worker->parameters;
-  user_name = call->user_name;  
+  user_name = call->user_name;
 
   // Check what kind of challenge we have
   if(call->user_name == NULL) {
@@ -412,7 +405,7 @@ static void _authGSSClientWrap(Worker *worker) {
   free(response);
 }
 
-static Handle<Value> _map_authGSSClientWrap(Worker *worker) {
+static Local<Value> _map_authGSSClientWrap(Worker *worker) {
   Nan::HandleScope scope;
   // Return the return code
   return Nan::New<Int32>(worker->return_code);
@@ -420,8 +413,6 @@ static Handle<Value> _map_authGSSClientWrap(Worker *worker) {
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSClientWrap) {
-  Nan::HandleScope scope;
-
   // Ensure valid call
     if(info.Length() != 3 && info.Length() != 4) return Nan::ThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
     if(info.Length() == 3 && (!KerberosContext::HasInstance(info[0]) || !info[1]->IsString() || !info[2]->IsFunction())) return Nan::ThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
@@ -430,7 +421,7 @@ NAN_METHOD(Kerberos::AuthGSSClientWrap) {
   // Challenge string
   char *challenge_str = NULL;
   char *user_name_str = NULL;
-  
+
   // Let's unpack the kerberos context
   Local<Object> object = info[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
@@ -445,7 +436,7 @@ NAN_METHOD(Kerberos::AuthGSSClientWrap) {
   challenge_str = (char *)calloc(challenge->Utf8Length() + 1, sizeof(char));
   if(challenge_str == NULL) die("Memory allocation failed");
   // Write v8 string to c-string
-  challenge->WriteUtf8(challenge_str);    
+  challenge->WriteUtf8(challenge_str);
 
   // If we have a user string
   if(info.Length() == 4) {
@@ -511,7 +502,7 @@ static void _authGSSClientClean(Worker *worker) {
   free(response);
 }
 
-static Handle<Value> _map_authGSSClientClean(Worker *worker) {
+static Local<Value> _map_authGSSClientClean(Worker *worker) {
   Nan::HandleScope scope;
   // Return the return code
   return Nan::New<Int32>(worker->return_code);
@@ -519,9 +510,7 @@ static Handle<Value> _map_authGSSClientClean(Worker *worker) {
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSClientClean) {
-  Nan::HandleScope scope;
-
-  // // Ensure valid call
+  // Ensure valid call
   if(info.Length() != 2) return Nan::ThrowError("Requires a GSS context and callback function");
   if(!KerberosContext::HasInstance(info[0]) || !info[1]->IsFunction()) return Nan::ThrowError("Requires a GSS context and callback function");
 
@@ -592,7 +581,7 @@ static void _authGSSServerInit(Worker *worker) {
   free(response);
 }
 
-static Handle<Value> _map_authGSSServerInit(Worker *worker) {
+static Local<Value> _map_authGSSServerInit(Worker *worker) {
   KerberosContext *context = KerberosContext::New();
   context->server_state = (gss_server_state *)worker->return_value;
   return context->handle();
@@ -600,8 +589,6 @@ static Handle<Value> _map_authGSSServerInit(Worker *worker) {
 
 // Server Initialize method
 NAN_METHOD(Kerberos::AuthGSSServerInit) {
-  Nan::HandleScope scope;
-
   // Ensure valid call
   if(info.Length() != 2) return Nan::ThrowError("Requires a service string service and a callback function");
   if(!info[0]->IsString() || !info[1]->IsFunction()) return Nan::ThrowError("Requires a service string service and a callback function");
@@ -664,7 +651,7 @@ static void _authGSSServerClean(Worker *worker) {
   free(response);
 }
 
-static Handle<Value> _map_authGSSServerClean(Worker *worker) {
+static Local<Value> _map_authGSSServerClean(Worker *worker) {
   Nan::HandleScope scope;
   // Return the return code
   return Nan::New<Int32>(worker->return_code);
@@ -672,8 +659,6 @@ static Handle<Value> _map_authGSSServerClean(Worker *worker) {
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSServerClean) {
-  Nan::HandleScope scope;
-
   // // Ensure valid call
   if(info.Length() != 2) return Nan::ThrowError("Requires a GSS context and callback function");
   if(!KerberosContext::HasInstance(info[0]) || !info[1]->IsFunction()) return Nan::ThrowError("Requires a GSS context and callback function");
@@ -748,7 +733,7 @@ static void _authGSSServerStep(Worker *worker) {
   free(response);
 }
 
-static Handle<Value> _map_authGSSServerStep(Worker *worker) {
+static Local<Value> _map_authGSSServerStep(Worker *worker) {
   Nan::HandleScope scope;
   // Return the return code
   return Nan::New<Int32>(worker->return_code);
@@ -756,8 +741,6 @@ static Handle<Value> _map_authGSSServerStep(Worker *worker) {
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSServerStep) {
-  Nan::HandleScope scope;
-
   // Ensure valid call
   if(info.Length() != 3) return Nan::ThrowError("Requires a GSS context, auth-data string and callback function");
   if(!KerberosContext::HasInstance(info[0]))  return Nan::ThrowError("1st arg must be a GSS context");
@@ -843,7 +826,7 @@ void Kerberos::After(uv_work_t* work_req) {
     }
   } else {
     // // Map the data
-    Handle<Value> result = worker->mapper(worker);
+    Local<Value> result = worker->mapper(worker);
     // Set up the callback with a null first
     #if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
       (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
@@ -873,8 +856,7 @@ void Kerberos::After(uv_work_t* work_req) {
 }
 
 // Exporting function
-extern "C" void init(Handle<Object> target) {
-  Nan::HandleScope scope;
+NAN_MODULE_INIT(init) {
   Kerberos::Initialize(target);
   KerberosContext::Initialize(target);
 }

--- a/lib/kerberos.cc
+++ b/lib/kerberos.cc
@@ -44,40 +44,40 @@ typedef struct AuthGSSClientCleanCall {
   KerberosContext *context;
 } AuthGSSClientCleanCall;
 
-Kerberos::Kerberos() : ObjectWrap() {
+Kerberos::Kerberos() : Nan::ObjectWrap() {
 }
 
-Persistent<FunctionTemplate> Kerberos::constructor_template;
+Nan::Persistent<FunctionTemplate> Kerberos::constructor_template;
 
 void Kerberos::Initialize(v8::Handle<v8::Object> target) {
   // Grab the scope of the call from Node
-  NanScope();
+  Nan::HandleScope scope;
 
   // Define a new function template
-  Local<FunctionTemplate> t = NanNew<FunctionTemplate>(New);
+  Local<FunctionTemplate> t = Nan::New<FunctionTemplate>(New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(NanNew<String>("Kerberos"));
+  t->SetClassName(Nan::New<String>("Kerberos").ToLocalChecked());
 
   // Set up method for the Kerberos instance
-  NODE_SET_PROTOTYPE_METHOD(t, "authGSSClientInit", AuthGSSClientInit);  
-  NODE_SET_PROTOTYPE_METHOD(t, "authGSSClientStep", AuthGSSClientStep);  
-  NODE_SET_PROTOTYPE_METHOD(t, "authGSSClientUnwrap", AuthGSSClientUnwrap);
-  NODE_SET_PROTOTYPE_METHOD(t, "authGSSClientWrap", AuthGSSClientWrap);
-  NODE_SET_PROTOTYPE_METHOD(t, "authGSSClientClean", AuthGSSClientClean);
+  Nan::SetPrototypeMethod(t, "authGSSClientInit", AuthGSSClientInit);  
+  Nan::SetPrototypeMethod(t, "authGSSClientStep", AuthGSSClientStep);  
+  Nan::SetPrototypeMethod(t, "authGSSClientUnwrap", AuthGSSClientUnwrap);
+  Nan::SetPrototypeMethod(t, "authGSSClientWrap", AuthGSSClientWrap);
+  Nan::SetPrototypeMethod(t, "authGSSClientClean", AuthGSSClientClean);
 
-  NanAssignPersistent(constructor_template, t);
+  constructor_template.Reset(t);
 
   // Set the symbol
-  target->ForceSet(NanNew<String>("Kerberos"), t->GetFunction());
+  target->ForceSet(Nan::New<String>("Kerberos").ToLocalChecked(), t->GetFunction());
 }
 
 NAN_METHOD(Kerberos::New) {
-  NanScope();
+  Nan::HandleScope scope;
   // Create a Kerberos instance
   Kerberos *kerberos = new Kerberos();
   // Return the kerberos object
-  kerberos->Wrap(args.This());
-  NanReturnValue(args.This());
+  kerberos->Wrap(info.This());
+  info.GetReturnValue().Set(info.This());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -117,19 +117,19 @@ static void _authGSSClientInit(Worker *worker) {
 static Handle<Value> _map_authGSSClientInit(Worker *worker) {
   KerberosContext *context = KerberosContext::New();
   context->state = (gss_client_state *)worker->return_value;
-  return NanObjectWrapHandle(context);
+  return context->handle();
 }
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSClientInit) {
-  NanScope();
+  Nan::HandleScope scope;
 
   // Ensure valid call
-  if(args.Length() != 3) return NanThrowError("Requires a service string uri, integer flags and a callback function");
-  if(args.Length() == 3 && !args[0]->IsString() && !args[1]->IsInt32() && !args[2]->IsFunction()) 
-      return NanThrowError("Requires a service string uri, integer flags and a callback function");    
+  if(info.Length() != 3) return Nan::ThrowError("Requires a service string uri, integer flags and a callback function");
+  if(info.Length() == 3 && !info[0]->IsString() && !info[1]->IsInt32() && !info[2]->IsFunction()) 
+      return Nan::ThrowError("Requires a service string uri, integer flags and a callback function");    
 
-  Local<String> service = args[0]->ToString();
+  Local<String> service = info[0]->ToString();
   // Convert uri string to c-string
   char *service_str = (char *)calloc(service->Utf8Length() + 1, sizeof(char));
   if(service_str == NULL) die("Memory allocation failed");
@@ -140,12 +140,12 @@ NAN_METHOD(Kerberos::AuthGSSClientInit) {
   // Allocate a structure
   AuthGSSClientCall *call = (AuthGSSClientCall *)calloc(1, sizeof(AuthGSSClientCall));
   if(call == NULL) die("Memory allocation failed");
-  call->flags =args[1]->ToInt32()->Uint32Value();
+  call->flags =info[1]->ToInt32()->Uint32Value();
   call->uri = service_str;
 
   // Unpack the callback
-  Local<Function> callbackHandle = Local<Function>::Cast(args[2]);
-  NanCallback *callback = new NanCallback(callbackHandle);
+  Local<Function> callbackHandle = Local<Function>::Cast(info[2]);
+  Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   // Let's allocate some space
   Worker *worker = new Worker();
@@ -159,7 +159,6 @@ NAN_METHOD(Kerberos::AuthGSSClientInit) {
   // Schedule the worker with lib_uv
   uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
   // Return no value as it's callback based
-  NanReturnValue(NanUndefined());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -200,30 +199,30 @@ static void _authGSSClientStep(Worker *worker) {
 }
 
 static Handle<Value> _map_authGSSClientStep(Worker *worker) {
-  NanScope();
+  Nan::HandleScope scope;
   // Return the return code
-  return NanNew<Int32>(worker->return_code);
+  return Nan::New<Int32>(worker->return_code);
 }
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSClientStep) {
-  NanScope();
+  Nan::HandleScope scope;
 
   // Ensure valid call
-  if(args.Length() != 2 && args.Length() != 3) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
-  if(args.Length() == 2 && !KerberosContext::HasInstance(args[0])) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
-  if(args.Length() == 3 && !KerberosContext::HasInstance(args[0]) && !args[1]->IsString()) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
+  if(info.Length() != 2 && info.Length() != 3) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
+  if(info.Length() == 2 && !KerberosContext::HasInstance(info[0])) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
+  if(info.Length() == 3 && !KerberosContext::HasInstance(info[0]) && !info[1]->IsString()) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
 
   // Challenge string
   char *challenge_str = NULL;
   // Let's unpack the parameters
-  Local<Object> object = args[0]->ToObject();
+  Local<Object> object = info[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
 
   // If we have a challenge string
-  if(args.Length() == 3) {
+  if(info.Length() == 3) {
     // Unpack the challenge string
-    Local<String> challenge = args[1]->ToString();
+    Local<String> challenge = info[1]->ToString();
     // Convert uri string to c-string
     challenge_str = (char *)calloc(challenge->Utf8Length() + 1, sizeof(char));
     if(challenge_str == NULL) die("Memory allocation failed");
@@ -238,8 +237,8 @@ NAN_METHOD(Kerberos::AuthGSSClientStep) {
   call->challenge = challenge_str;
 
   // Unpack the callback
-  Local<Function> callbackHandle = Local<Function>::Cast(args[2]);
-  NanCallback *callback = new NanCallback(callbackHandle);
+  Local<Function> callbackHandle = Local<Function>::Cast(info[2]);
+  Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   // Let's allocate some space
   Worker *worker = new Worker();
@@ -254,7 +253,6 @@ NAN_METHOD(Kerberos::AuthGSSClientStep) {
   uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
 
   // Return no value as it's callback based
-  NanReturnValue(NanUndefined());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -292,30 +290,30 @@ static void _authGSSClientUnwrap(Worker *worker) {
 }
 
 static Handle<Value> _map_authGSSClientUnwrap(Worker *worker) {
-  NanScope();
+  Nan::HandleScope scope;
   // Return the return code
-  return NanNew<Int32>(worker->return_code);
+  return Nan::New<Int32>(worker->return_code);
 }
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSClientUnwrap) {
-  NanScope();
+  Nan::HandleScope scope;
 
   // Ensure valid call
-  if(args.Length() != 2 && args.Length() != 3) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
-  if(args.Length() == 2 && !KerberosContext::HasInstance(args[0]) && !args[1]->IsFunction()) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
-  if(args.Length() == 3 && !KerberosContext::HasInstance(args[0]) && !args[1]->IsString() && !args[2]->IsFunction()) return NanThrowError("Requires a GSS context, optional challenge string and callback function");
+  if(info.Length() != 2 && info.Length() != 3) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
+  if(info.Length() == 2 && !KerberosContext::HasInstance(info[0]) && !info[1]->IsFunction()) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
+  if(info.Length() == 3 && !KerberosContext::HasInstance(info[0]) && !info[1]->IsString() && !info[2]->IsFunction()) return Nan::ThrowError("Requires a GSS context, optional challenge string and callback function");
 
   // Challenge string
   char *challenge_str = NULL;
   // Let's unpack the parameters
-  Local<Object> object = args[0]->ToObject();
+  Local<Object> object = info[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
 
   // If we have a challenge string
-  if(args.Length() == 3) {
+  if(info.Length() == 3) {
     // Unpack the challenge string
-    Local<String> challenge = args[1]->ToString();
+    Local<String> challenge = info[1]->ToString();
     // Convert uri string to c-string
     challenge_str = (char *)calloc(challenge->Utf8Length() + 1, sizeof(char));
     if(challenge_str == NULL) die("Memory allocation failed");
@@ -330,8 +328,8 @@ NAN_METHOD(Kerberos::AuthGSSClientUnwrap) {
   call->challenge = challenge_str;
 
   // Unpack the callback
-  Local<Function> callbackHandle = args.Length() == 3 ? Local<Function>::Cast(args[2]) : Local<Function>::Cast(args[1]);
-  NanCallback *callback = new NanCallback(callbackHandle);
+  Local<Function> callbackHandle = info.Length() == 3 ? Local<Function>::Cast(info[2]) : Local<Function>::Cast(info[1]);
+  Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   // Let's allocate some space
   Worker *worker = new Worker();
@@ -347,7 +345,6 @@ NAN_METHOD(Kerberos::AuthGSSClientUnwrap) {
 
   // Return no value as it's callback based
   // return scope.Close(NanUndefined());
-  NanReturnValue(NanUndefined());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -386,30 +383,30 @@ static void _authGSSClientWrap(Worker *worker) {
 }
 
 static Handle<Value> _map_authGSSClientWrap(Worker *worker) {
-  NanScope();
+  Nan::HandleScope scope;
   // Return the return code
-  return NanNew<Int32>(worker->return_code);
+  return Nan::New<Int32>(worker->return_code);
 }
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSClientWrap) {
-  NanScope();
+  Nan::HandleScope scope;
 
   // Ensure valid call
-  if(args.Length() != 3 && args.Length() != 4) return NanThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
-  if(args.Length() == 3 && !KerberosContext::HasInstance(args[0]) && !args[1]->IsString() && !args[2]->IsFunction()) return NanThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
-  if(args.Length() == 4 && !KerberosContext::HasInstance(args[0]) && !args[1]->IsString() && !args[2]->IsString() && !args[2]->IsFunction()) return NanThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
+  if(info.Length() != 3 && info.Length() != 4) return Nan::ThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
+  if(info.Length() == 3 && !KerberosContext::HasInstance(info[0]) && !info[1]->IsString() && !info[2]->IsFunction()) return Nan::ThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
+  if(info.Length() == 4 && !KerberosContext::HasInstance(info[0]) && !info[1]->IsString() && !info[2]->IsString() && !info[2]->IsFunction()) return Nan::ThrowError("Requires a GSS context, the result from the authGSSClientResponse after authGSSClientUnwrap, optional user name and callback function");
 
   // Challenge string
   char *challenge_str = NULL;
   char *user_name_str = NULL;
   
   // Let's unpack the kerberos context
-  Local<Object> object = args[0]->ToObject();
+  Local<Object> object = info[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
 
   // Unpack the challenge string
-  Local<String> challenge = args[1]->ToString();
+  Local<String> challenge = info[1]->ToString();
   // Convert uri string to c-string
   challenge_str = (char *)calloc(challenge->Utf8Length() + 1, sizeof(char));
   if(challenge_str == NULL) die("Memory allocation failed");
@@ -417,9 +414,9 @@ NAN_METHOD(Kerberos::AuthGSSClientWrap) {
   challenge->WriteUtf8(challenge_str);    
 
   // If we have a user string
-  if(args.Length() == 4) {
+  if(info.Length() == 4) {
     // Unpack user name
-    Local<String> user_name = args[2]->ToString();
+    Local<String> user_name = info[2]->ToString();
     // Convert uri string to c-string
     user_name_str = (char *)calloc(user_name->Utf8Length() + 1, sizeof(char));
     if(user_name_str == NULL) die("Memory allocation failed");
@@ -435,8 +432,8 @@ NAN_METHOD(Kerberos::AuthGSSClientWrap) {
   call->user_name = user_name_str;
 
   // Unpack the callback
-  Local<Function> callbackHandle = args.Length() == 4 ? Local<Function>::Cast(args[3]) : Local<Function>::Cast(args[2]);
-  NanCallback *callback = new NanCallback(callbackHandle);
+  Local<Function> callbackHandle = info.Length() == 4 ? Local<Function>::Cast(info[3]) : Local<Function>::Cast(info[2]);
+  Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   // Let's allocate some space
   Worker *worker = new Worker();
@@ -451,7 +448,6 @@ NAN_METHOD(Kerberos::AuthGSSClientWrap) {
   uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
 
   // Return no value as it's callback based
-  NanReturnValue(NanUndefined());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -481,21 +477,21 @@ static void _authGSSClientClean(Worker *worker) {
 }
 
 static Handle<Value> _map_authGSSClientClean(Worker *worker) {
-  NanScope();
+  Nan::HandleScope scope;
   // Return the return code
-  return NanNew<Int32>(worker->return_code);
+  return Nan::New<Int32>(worker->return_code);
 }
 
 // Initialize method
 NAN_METHOD(Kerberos::AuthGSSClientClean) {
-  NanScope();
+  Nan::HandleScope scope;
 
   // // Ensure valid call
-  if(args.Length() != 2) return NanThrowError("Requires a GSS context and callback function");
-  if(!KerberosContext::HasInstance(args[0]) && !args[1]->IsFunction()) return NanThrowError("Requires a GSS context and callback function");
+  if(info.Length() != 2) return Nan::ThrowError("Requires a GSS context and callback function");
+  if(!KerberosContext::HasInstance(info[0]) && !info[1]->IsFunction()) return Nan::ThrowError("Requires a GSS context and callback function");
 
   // Let's unpack the kerberos context
-  Local<Object> object = args[0]->ToObject();
+  Local<Object> object = info[0]->ToObject();
   KerberosContext *kerberos_context = KerberosContext::Unwrap<KerberosContext>(object);
 
   // Allocate a structure
@@ -504,8 +500,8 @@ NAN_METHOD(Kerberos::AuthGSSClientClean) {
   call->context = kerberos_context;
 
   // Unpack the callback
-  Local<Function> callbackHandle = Local<Function>::Cast(args[1]);
-  NanCallback *callback = new NanCallback(callbackHandle);
+  Local<Function> callbackHandle = Local<Function>::Cast(info[1]);
+  Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   // Let's allocate some space
   Worker *worker = new Worker();
@@ -520,7 +516,6 @@ NAN_METHOD(Kerberos::AuthGSSClientClean) {
   uv_queue_work(uv_default_loop(), &worker->request, Kerberos::Process, (uv_after_work_cb)Kerberos::After);
 
   // Return no value as it's callback based
-  NanReturnValue(NanUndefined());
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -535,45 +530,45 @@ void Kerberos::Process(uv_work_t* work_req) {
 
 void Kerberos::After(uv_work_t* work_req) {
   // Grab the scope of the call from Node
-  NanScope();
+  Nan::HandleScope scope;
 
   // Get the worker reference
   Worker *worker = static_cast<Worker*>(work_req->data);
 
   // If we have an error
   if(worker->error) {
-    Local<Value> err = v8::Exception::Error(NanNew<String>(worker->error_message));
+    Local<Value> err = v8::Exception::Error(Nan::New<String>(worker->error_message).ToLocalChecked());
     Local<Object> obj = err->ToObject();
-    obj->Set(NanNew<String>("code"), NanNew<Int32>(worker->error_code));
-    Local<Value> args[2] = { err, NanNull() };
+    obj->Set(Nan::New<String>("code").ToLocalChecked(), Nan::New<Int32>(worker->error_code));
+    Local<Value> info[2] = { err, Nan::Null() };
     // Execute the error
-    v8::TryCatch try_catch;
+    Nan::TryCatch try_catch;
 
     // Call the callback
-    worker->callback->Call(ARRAY_SIZE(args), args);
+    worker->callback->Call(ARRAY_SIZE(info), info);
 
     // If we have an exception handle it as a fatalexception
     if (try_catch.HasCaught()) {
-      node::FatalException(try_catch);
+      Nan::FatalException(try_catch);
     }
   } else {
     // // Map the data
     Handle<Value> result = worker->mapper(worker);
     // Set up the callback with a null first
-    Handle<Value> args[2] = { NanNull(), result};
+    Handle<Value> info[2] = { Nan::Null(), result};
 
     // Wrap the callback function call in a TryCatch so that we can call
     // node's FatalException afterwards. This makes it possible to catch
     // the exception from JavaScript land using the
     // process.on('uncaughtException') event.
-    v8::TryCatch try_catch;
+    Nan::TryCatch try_catch;
 
     // Call the callback
-    worker->callback->Call(ARRAY_SIZE(args), args);
+    worker->callback->Call(ARRAY_SIZE(info), info);
 
     // If we have an exception handle it as a fatalexception
     if (try_catch.HasCaught()) {
-      node::FatalException(try_catch);
+      Nan::FatalException(try_catch);
     }
   }
 
@@ -584,7 +579,7 @@ void Kerberos::After(uv_work_t* work_req) {
 
 // Exporting function
 extern "C" void init(Handle<Object> target) {
-  NanScope();
+  Nan::HandleScope scope;
   Kerberos::Initialize(target);
   KerberosContext::Initialize(target);
 }

--- a/lib/kerberos.h
+++ b/lib/kerberos.h
@@ -27,7 +27,7 @@ public:
   static Nan::Persistent<FunctionTemplate> constructor_template;
 
   // Initialize function for the object
-  static void Initialize(Handle<Object> target);
+  static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
 
   // Method available
   static NAN_METHOD(AuthGSSClientInit);

--- a/lib/kerberos.h
+++ b/lib/kerberos.h
@@ -17,14 +17,14 @@ extern "C" {
 using namespace v8;
 using namespace node;
 
-class Kerberos : public ObjectWrap {
+class Kerberos : public Nan::ObjectWrap {
 
 public:
   Kerberos();
   ~Kerberos() {};
 
   // Constructor used for creating new Kerberos objects from C++
-  static Persistent<FunctionTemplate> constructor_template;
+  static Nan::Persistent<FunctionTemplate> constructor_template;
 
   // Initialize function for the object
   static void Initialize(Handle<Object> target);

--- a/lib/kerberos_context.cc
+++ b/lib/kerberos_context.cc
@@ -11,14 +11,13 @@ KerberosContext::~KerberosContext() {
 }
 
 KerberosContext* KerberosContext::New() {
-  Nan::HandleScope scope; 
+  Nan::HandleScope scope;
   Local<Object> obj = Nan::New(constructor_template)->GetFunction()->NewInstance();
-  KerberosContext *kerberos_context = Nan::ObjectWrap::Unwrap<KerberosContext>(obj);  
+  KerberosContext *kerberos_context = Nan::ObjectWrap::Unwrap<KerberosContext>(obj);
   return kerberos_context;
 }
 
 NAN_METHOD(KerberosContext::New) {
-  Nan::HandleScope scope;
   // Create code object
   KerberosContext *kerberos_context = new KerberosContext();
   // Wrap it
@@ -27,7 +26,7 @@ NAN_METHOD(KerberosContext::New) {
   info.GetReturnValue().Set(info.This());
 }
 
-void KerberosContext::Initialize(v8::Handle<v8::Object> target) {
+void KerberosContext::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   // Grab the scope of the call from Node
   Nan::HandleScope scope;
 
@@ -60,7 +59,6 @@ void KerberosContext::Initialize(v8::Handle<v8::Object> target) {
 
 // Response Setter / Getter
 NAN_GETTER(KerberosContext::ResponseGetter) {
-  Nan::HandleScope scope;
   gss_client_state *client_state;
   gss_server_state *server_state;
 
@@ -85,8 +83,6 @@ NAN_GETTER(KerberosContext::ResponseGetter) {
 
 // username Getter
 NAN_GETTER(KerberosContext::UsernameGetter) {
-  Nan::HandleScope scope;
-
   // Unpack the object
   KerberosContext *context = Nan::ObjectWrap::Unwrap<KerberosContext>(info.This());
 
@@ -106,8 +102,6 @@ NAN_GETTER(KerberosContext::UsernameGetter) {
 
 // targetname Getter - server side only
 NAN_GETTER(KerberosContext::TargetnameGetter) {
-  Nan::HandleScope scope;
-
   // Unpack the object
   KerberosContext *context = Nan::ObjectWrap::Unwrap<KerberosContext>(info.This());
 

--- a/lib/kerberos_context.cc
+++ b/lib/kerberos_context.cc
@@ -1,69 +1,70 @@
 #include "kerberos_context.h"
 
-Persistent<FunctionTemplate> KerberosContext::constructor_template;
+Nan::Persistent<FunctionTemplate> KerberosContext::constructor_template;
 
-KerberosContext::KerberosContext() : ObjectWrap() {
+KerberosContext::KerberosContext() : Nan::ObjectWrap() {
 }
 
 KerberosContext::~KerberosContext() {
 }
 
 KerberosContext* KerberosContext::New() {
-  NanScope();  
-  Local<Object> obj = NanNew(constructor_template)->GetFunction()->NewInstance();
-  KerberosContext *kerberos_context = ObjectWrap::Unwrap<KerberosContext>(obj);  
+  Nan::HandleScope scope; 
+  Local<Object> obj = Nan::New(constructor_template)->GetFunction()->NewInstance();
+  KerberosContext *kerberos_context = Nan::ObjectWrap::Unwrap<KerberosContext>(obj);  
   return kerberos_context;
 }
 
 NAN_METHOD(KerberosContext::New) {
-  NanScope();
+  Nan::HandleScope scope;
   // Create code object
   KerberosContext *kerberos_context = new KerberosContext();
   // Wrap it
-  kerberos_context->Wrap(args.This());
+  kerberos_context->Wrap(info.This());
   // Return the object
-  NanReturnValue(args.This());
+  info.GetReturnValue().Set(info.This());
 }
 
 void KerberosContext::Initialize(v8::Handle<v8::Object> target) {
   // Grab the scope of the call from Node
-  NanScope();
+  Nan::HandleScope scope;
 
   // Define a new function template
   // Local<FunctionTemplate> t = NanNew<FunctionTemplate>(New);
-  Local<FunctionTemplate> t = NanNew<v8::FunctionTemplate>(static_cast<NAN_METHOD((*))>(New));
+  Local<FunctionTemplate> t = Nan::New<v8::FunctionTemplate>(static_cast<NAN_METHOD((*))>(New));
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(NanNew<String>("KerberosContext"));
+  t->SetClassName(Nan::New<String>("KerberosContext").ToLocalChecked());
 
   // Get prototype
   Local<ObjectTemplate> proto = t->PrototypeTemplate();
 
   // Getter for the response
-  proto->SetAccessor(NanNew<String>("response"), KerberosContext::ResponseGetter);
+  Nan::SetAccessor(proto, Nan::New<String>("response").ToLocalChecked(), KerberosContext::ResponseGetter);
 
   // Set persistent
-  NanAssignPersistent(constructor_template, t);
+  constructor_template.Reset(t);
+ // NanAssignPersistent(constructor_template, t);
 
   // Set the symbol
-  target->ForceSet(NanNew<String>("KerberosContext"), t->GetFunction());
+  target->ForceSet(Nan::New<String>("KerberosContext").ToLocalChecked(), t->GetFunction());
 }
 
 //
 // Response Setter / Getter
 NAN_GETTER(KerberosContext::ResponseGetter) {
-  NanScope();
+  Nan::HandleScope scope;
   gss_client_state *state;
 
   // Unpack the object
-  KerberosContext *context = ObjectWrap::Unwrap<KerberosContext>(args.This());
+  KerberosContext *context = Nan::ObjectWrap::Unwrap<KerberosContext>(info.This());
   // Let's grab the response
   state = context->state;
   // No state no response
   if(state == NULL || state->response == NULL) {
-    NanReturnValue(NanNull());
+    info.GetReturnValue().Set(Nan::Null());
   } else {
     // Return the response
-    NanReturnValue(NanNew<String>(state->response));
+    info.GetReturnValue().Set(Nan::New<String>(state->response).ToLocalChecked());
   }
 }
 

--- a/lib/kerberos_context.cc
+++ b/lib/kerberos_context.cc
@@ -44,10 +44,10 @@ void KerberosContext::Initialize(v8::Handle<v8::Object> target) {
   Nan::SetAccessor(proto, Nan::New<String>("response").ToLocalChecked(), KerberosContext::ResponseGetter);
 
   // Getter for the username
-  proto->SetAccessor(NanNew<String>("username"), KerberosContext::UsernameGetter);
+  Nan::SetAccessor(proto, Nan::New<String>("username").ToLocalChecked(), KerberosContext::UsernameGetter);
 
   // Getter for the targetname - server side only
-  proto->SetAccessor(NanNew<String>("targetname"), KerberosContext::TargetnameGetter);
+  Nan::SetAccessor(proto, Nan::New<String>("targetname").ToLocalChecked(), KerberosContext::TargetnameGetter);
 
   // Set persistent
   constructor_template.Reset(t);
@@ -65,7 +65,7 @@ NAN_GETTER(KerberosContext::ResponseGetter) {
   gss_server_state *server_state;
 
   // Unpack the object
-      KerberosContext *context = Nan::ObjectWrap::Unwrap<KerberosContext>(info.This());
+  KerberosContext *context = Nan::ObjectWrap::Unwrap<KerberosContext>(info.This());
 
   // Response could come from client or server state...
   client_state = context->state;
@@ -85,10 +85,10 @@ NAN_GETTER(KerberosContext::ResponseGetter) {
 
 // username Getter
 NAN_GETTER(KerberosContext::UsernameGetter) {
-  NanScope();
+  Nan::HandleScope scope;
 
   // Unpack the object
-  KerberosContext *context = ObjectWrap::Unwrap<KerberosContext>(args.This());
+  KerberosContext *context = Nan::ObjectWrap::Unwrap<KerberosContext>(info.This());
 
   gss_client_state *client_state = context->state;
   gss_server_state *server_state = context->server_state;
@@ -98,26 +98,26 @@ NAN_GETTER(KerberosContext::UsernameGetter) {
 	  server_state != NULL ? server_state->username : NULL;
 
   if(username == NULL) {
-    NanReturnValue(NanNull());
+    info.GetReturnValue().Set(Nan::Null());
   } else {
-    NanReturnValue(NanNew<String>(username));
+    info.GetReturnValue().Set(Nan::New<String>(username).ToLocalChecked());
   }
 }
 
 // targetname Getter - server side only
 NAN_GETTER(KerberosContext::TargetnameGetter) {
-  NanScope();
+  Nan::HandleScope scope;
 
   // Unpack the object
-  KerberosContext *context = ObjectWrap::Unwrap<KerberosContext>(args.This());
+  KerberosContext *context = Nan::ObjectWrap::Unwrap<KerberosContext>(info.This());
 
   gss_server_state *server_state = context->server_state;
 
   char *targetname = server_state != NULL ? server_state->targetname : NULL;
 
   if(targetname == NULL) {
-    NanReturnValue(NanNull());
+    info.GetReturnValue().Set(Nan::Null());
   } else {
-    NanReturnValue(NanNew<String>(targetname));
+    info.GetReturnValue().Set(Nan::New<String>(targetname).ToLocalChecked());
   }
 }

--- a/lib/kerberos_context.h
+++ b/lib/kerberos_context.h
@@ -23,7 +23,7 @@ public:
   KerberosContext();
   ~KerberosContext();
 
-  static inline bool HasInstance(Handle<Value> val) {
+  static inline bool HasInstance(Local<Value> val) {
     if (!val->IsObject()) return false;
     Local<Object> obj = val->ToObject();
     return Nan::New(constructor_template)->HasInstance(obj);
@@ -41,7 +41,7 @@ public:
   static Nan::Persistent<FunctionTemplate> constructor_template;
 
   // Initialize function for the object
-  static void Initialize(Handle<Object> target);
+  static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
 
   // Public constructor
   static KerberosContext* New();

--- a/lib/kerberos_context.h
+++ b/lib/kerberos_context.h
@@ -17,7 +17,7 @@ extern "C" {
 using namespace v8;
 using namespace node;
 
-class KerberosContext : public ObjectWrap {
+class KerberosContext : public Nan::ObjectWrap {
 
 public:
   KerberosContext();
@@ -26,11 +26,11 @@ public:
   static inline bool HasInstance(Handle<Value> val) {
     if (!val->IsObject()) return false;
     Local<Object> obj = val->ToObject();
-    return NanNew(constructor_template)->HasInstance(obj);
+    return Nan::New(constructor_template)->HasInstance(obj);
   };
 
   // Constructor used for creating new Kerberos objects from C++
-  static Persistent<FunctionTemplate> constructor_template;
+  static Nan::Persistent<FunctionTemplate> constructor_template;
 
   // Initialize function for the object
   static void Initialize(Handle<Object> target);

--- a/lib/win32/kerberos.cc
+++ b/lib/win32/kerberos.cc
@@ -12,7 +12,7 @@ Nan::Persistent<FunctionTemplate> Kerberos::constructor_template;
 Kerberos::Kerberos() : Nan::ObjectWrap() {
 }
 
-void Kerberos::Initialize(v8::Handle<v8::Object> target) {
+void Kerberos::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   // Grab the scope of the call from Node
   Nan::HandleScope scope;
 
@@ -25,11 +25,10 @@ void Kerberos::Initialize(v8::Handle<v8::Object> target) {
   constructor_template.Reset(t);
 
   // Set the symbol
-  target->ForceSet(Nan::New<String>("Kerberos").ToLocalChecked(), t->GetFunction());
+  Nan::Set(target, Nan::New<String>("Kerberos").ToLocalChecked(), t->GetFunction());
 }
 
 NAN_METHOD(Kerberos::New) {
-  Nan::HandleScope scope;
   // Load the security.dll library
   load_library();
   // Create a Kerberos instance
@@ -41,8 +40,7 @@ NAN_METHOD(Kerberos::New) {
 }
 
 // Exporting function
-extern "C" void init(Handle<Object> target) {
-  Nan::HandleScope scope;
+NAN_MODULE_INIT(init) {
   Kerberos::Initialize(target);
   SecurityContext::Initialize(target);
   SecurityBuffer::Initialize(target);

--- a/lib/win32/kerberos.cc
+++ b/lib/win32/kerberos.cc
@@ -7,42 +7,42 @@
 #include "wrappers/security_context.h"
 #include "wrappers/security_credentials.h"
 
-Persistent<FunctionTemplate> Kerberos::constructor_template;
+Nan::Persistent<FunctionTemplate> Kerberos::constructor_template;
 
-Kerberos::Kerberos() : ObjectWrap() {
+Kerberos::Kerberos() : Nan::ObjectWrap() {
 }
 
 void Kerberos::Initialize(v8::Handle<v8::Object> target) {
   // Grab the scope of the call from Node
-  NanScope();
+  Nan::HandleScope scope;
 
   // Define a new function template
-  Local<FunctionTemplate> t = NanNew<FunctionTemplate>(New);
+  Local<FunctionTemplate> t = Nan::New<FunctionTemplate>(New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(NanNew<String>("Kerberos"));
+  t->SetClassName(Nan::New<String>("Kerberos").ToLocalChecked());
 
   // Set persistent
-  NanAssignPersistent(constructor_template, t);
+  constructor_template.Reset(t);
 
   // Set the symbol
-  target->ForceSet(NanNew<String>("Kerberos"), t->GetFunction());
+  target->ForceSet(Nan::New<String>("Kerberos").ToLocalChecked(), t->GetFunction());
 }
 
 NAN_METHOD(Kerberos::New) {
-  NanScope();
+  Nan::HandleScope scope;
   // Load the security.dll library
   load_library();
   // Create a Kerberos instance
   Kerberos *kerberos = new Kerberos();
   // Return the kerberos object
-  kerberos->Wrap(args.This());
+  kerberos->Wrap(info.This());
   // Return the object
-  NanReturnValue(args.This());
+  info.GetReturnValue().Set(info.This());
 }
 
 // Exporting function
 extern "C" void init(Handle<Object> target) {
-  NanScope();
+  Nan::HandleScope scope;
   Kerberos::Initialize(target);
   SecurityContext::Initialize(target);
   SecurityBuffer::Initialize(target);

--- a/lib/win32/kerberos.h
+++ b/lib/win32/kerberos.h
@@ -14,14 +14,14 @@ extern "C" {
 using namespace v8;
 using namespace node;
 
-class Kerberos : public ObjectWrap {
+class Kerberos : public Nan::ObjectWrap {
 
 public:
   Kerberos();
   ~Kerberos() {};
 
   // Constructor used for creating new Kerberos objects from C++
-  static Persistent<FunctionTemplate> constructor_template;
+  static Nan::Persistent<FunctionTemplate> constructor_template;
 
   // Initialize function for the object
   static void Initialize(Handle<Object> target);

--- a/lib/win32/kerberos.h
+++ b/lib/win32/kerberos.h
@@ -24,7 +24,7 @@ public:
   static Nan::Persistent<FunctionTemplate> constructor_template;
 
   // Initialize function for the object
-  static void Initialize(Handle<Object> target);
+  static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
 
   // Method available
   static NAN_METHOD(AcquireAlternateCredentials);

--- a/lib/win32/worker.h
+++ b/lib/win32/worker.h
@@ -32,7 +32,7 @@ class Worker {
     int return_code;
     // Method we are going to fire
     void (*execute)(Worker *worker);
-    Handle<Value> (*mapper)(Worker *worker);
+    Local<Value> (*mapper)(Worker *worker);
 };
 
 #endif  // WORKER_H_

--- a/lib/win32/worker.h
+++ b/lib/win32/worker.h
@@ -4,7 +4,7 @@
 #include <node.h>
 #include <node_object_wrap.h>
 #include <v8.h>
-#include "nan.h"
+#include <nan.h>
 
 using namespace node;
 using namespace v8;
@@ -17,7 +17,7 @@ class Worker {
     // libuv's request struct.
     uv_work_t request;
     // Callback
-    NanCallback *callback;
+    Nan::Callback *callback;
     // Parameters
     void *parameters;
     // Results

--- a/lib/win32/wrappers/security_buffer.cc
+++ b/lib/win32/wrappers/security_buffer.cc
@@ -14,9 +14,9 @@
 
 using namespace node;
 
-Persistent<FunctionTemplate> SecurityBuffer::constructor_template;
+Nan::Persistent<FunctionTemplate> SecurityBuffer::constructor_template;
 
-SecurityBuffer::SecurityBuffer(uint32_t security_type, size_t size) : ObjectWrap() {
+SecurityBuffer::SecurityBuffer(uint32_t security_type, size_t size) : Nan::ObjectWrap() {
   this->size = size;
   this->data = calloc(size, sizeof(char));
   this->security_type = security_type;
@@ -26,7 +26,7 @@ SecurityBuffer::SecurityBuffer(uint32_t security_type, size_t size) : ObjectWrap
   this->sec_buffer.pvBuffer = this->data;  
 }
 
-SecurityBuffer::SecurityBuffer(uint32_t security_type, size_t size, void *data) : ObjectWrap() {
+SecurityBuffer::SecurityBuffer(uint32_t security_type, size_t size, void *data) : Nan::ObjectWrap() {
   this->size = size;
   this->data = data;
   this->security_type = security_type;
@@ -41,66 +41,66 @@ SecurityBuffer::~SecurityBuffer() {
 }
 
 NAN_METHOD(SecurityBuffer::New) {
-  NanScope();
+  Nan::HandleScope scope;
   SecurityBuffer *security_obj;
 
-  if(args.Length() != 2)
-    return NanThrowError("Two parameters needed integer buffer type and  [32 bit integer/Buffer] required");
+  if(info.Length() != 2)
+    return Nan::ThrowError("Two parameters needed integer buffer type and  [32 bit integer/Buffer] required");
 
-  if(!args[0]->IsInt32())
-    return NanThrowError("Two parameters needed integer buffer type and  [32 bit integer/Buffer] required");
+  if(!info[0]->IsInt32())
+    return Nan::ThrowError("Two parameters needed integer buffer type and  [32 bit integer/Buffer] required");
 
-  if(!args[1]->IsInt32() && !Buffer::HasInstance(args[1]))
-    return NanThrowError("Two parameters needed integer buffer type and  [32 bit integer/Buffer] required");
+  if(!info[1]->IsInt32() && !Buffer::HasInstance(info[1]))
+    return Nan::ThrowError("Two parameters needed integer buffer type and  [32 bit integer/Buffer] required");
 
   // Unpack buffer type
-  uint32_t buffer_type = args[0]->ToUint32()->Value();
+  uint32_t buffer_type = info[0]->ToUint32()->Value();
 
   // If we have an integer
-  if(args[1]->IsInt32()) {
-    security_obj = new SecurityBuffer(buffer_type, args[1]->ToUint32()->Value());
+  if(info[1]->IsInt32()) {
+    security_obj = new SecurityBuffer(buffer_type, info[1]->ToUint32()->Value());
   } else {
     // Get the length of the Buffer
-    size_t length = Buffer::Length(args[1]->ToObject());
+    size_t length = Buffer::Length(info[1]->ToObject());
     // Allocate space for the internal void data pointer
     void *data = calloc(length, sizeof(char));
     // Write the data to out of V8 heap space
-    memcpy(data, Buffer::Data(args[1]->ToObject()), length);
+    memcpy(data, Buffer::Data(info[1]->ToObject()), length);
     // Create new SecurityBuffer
     security_obj = new SecurityBuffer(buffer_type, length, data);
   }
   
   // Wrap it
-  security_obj->Wrap(args.This());
+  security_obj->Wrap(info.This());
   // Return the object
-  NanReturnValue(args.This());
+  info.GetReturnValue().Set(info.This());
 }
 
 NAN_METHOD(SecurityBuffer::ToBuffer) {
-  NanScope();
+  Nan::HandleScope scope;
   // Unpack the Security Buffer object
-  SecurityBuffer *security_obj = ObjectWrap::Unwrap<SecurityBuffer>(args.This());
+  SecurityBuffer *security_obj = Nan::ObjectWrap::Unwrap<SecurityBuffer>(info.This());
   // Create a Buffer
-  Local<Object> buffer = NanNewBufferHandle((char *)security_obj->data, (uint32_t)security_obj->size);
+  Local<Object> buffer = Nan::CopyBuffer((char *)security_obj->data, (uint32_t)security_obj->size).ToLocalChecked();
   // Return the buffer
-  NanReturnValue(buffer);
+  info.GetReturnValue().Set(buffer);
 }
 
 void SecurityBuffer::Initialize(Handle<Object> target) {
   // Grab the scope of the call from Node
-  NanScope();
+  Nan::HandleScope scope;
 
   // Define a new function template
-  Local<FunctionTemplate> t = NanNew<FunctionTemplate>(New);
+  Local<FunctionTemplate> t = Nan::New<FunctionTemplate>(New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(NanNew<String>("SecurityBuffer"));
+  t->SetClassName(Nan::New<String>("SecurityBuffer").ToLocalChecked());
 
   // Class methods
-  NODE_SET_PROTOTYPE_METHOD(t, "toBuffer", ToBuffer);
+  Nan::SetPrototypeMethod(t, "toBuffer", ToBuffer);
 
   // Set persistent
-  NanAssignPersistent(constructor_template, t);
+  constructor_template.Reset(t);
 
   // Set the symbol
-  target->ForceSet(NanNew<String>("SecurityBuffer"), t->GetFunction());
+  target->ForceSet(Nan::New<String>("SecurityBuffer").ToLocalChecked(), t->GetFunction());
 }

--- a/lib/win32/wrappers/security_buffer.cc
+++ b/lib/win32/wrappers/security_buffer.cc
@@ -23,7 +23,7 @@ SecurityBuffer::SecurityBuffer(uint32_t security_type, size_t size) : Nan::Objec
   // Set up the data in the sec_buffer
   this->sec_buffer.BufferType = security_type;
   this->sec_buffer.cbBuffer = (unsigned long)size;
-  this->sec_buffer.pvBuffer = this->data;  
+  this->sec_buffer.pvBuffer = this->data;
 }
 
 SecurityBuffer::SecurityBuffer(uint32_t security_type, size_t size, void *data) : Nan::ObjectWrap() {
@@ -33,7 +33,7 @@ SecurityBuffer::SecurityBuffer(uint32_t security_type, size_t size, void *data) 
   // Set up the data in the sec_buffer
   this->sec_buffer.BufferType = security_type;
   this->sec_buffer.cbBuffer = (unsigned long)size;
-  this->sec_buffer.pvBuffer = this->data;  
+  this->sec_buffer.pvBuffer = this->data;
 }
 
 SecurityBuffer::~SecurityBuffer() {
@@ -41,7 +41,6 @@ SecurityBuffer::~SecurityBuffer() {
 }
 
 NAN_METHOD(SecurityBuffer::New) {
-  Nan::HandleScope scope;
   SecurityBuffer *security_obj;
 
   if(info.Length() != 2)
@@ -69,7 +68,7 @@ NAN_METHOD(SecurityBuffer::New) {
     // Create new SecurityBuffer
     security_obj = new SecurityBuffer(buffer_type, length, data);
   }
-  
+
   // Wrap it
   security_obj->Wrap(info.This());
   // Return the object
@@ -77,7 +76,6 @@ NAN_METHOD(SecurityBuffer::New) {
 }
 
 NAN_METHOD(SecurityBuffer::ToBuffer) {
-  Nan::HandleScope scope;
   // Unpack the Security Buffer object
   SecurityBuffer *security_obj = Nan::ObjectWrap::Unwrap<SecurityBuffer>(info.This());
   // Create a Buffer
@@ -86,10 +84,7 @@ NAN_METHOD(SecurityBuffer::ToBuffer) {
   info.GetReturnValue().Set(buffer);
 }
 
-void SecurityBuffer::Initialize(Handle<Object> target) {
-  // Grab the scope of the call from Node
-  Nan::HandleScope scope;
-
+void SecurityBuffer::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   // Define a new function template
   Local<FunctionTemplate> t = Nan::New<FunctionTemplate>(New);
   t->InstanceTemplate()->SetInternalFieldCount(1);

--- a/lib/win32/wrappers/security_buffer.h
+++ b/lib/win32/wrappers/security_buffer.h
@@ -15,11 +15,11 @@
 using namespace v8;
 using namespace node;
 
-class SecurityBuffer : public Nan::ObjectWrap {  
-  public:    
+class SecurityBuffer : public Nan::ObjectWrap {
+  public:
     SecurityBuffer(uint32_t security_type, size_t size);
     SecurityBuffer(uint32_t security_type, size_t size, void *data);
-    ~SecurityBuffer();    
+    ~SecurityBuffer();
 
     // Internal values
     void *data;
@@ -28,19 +28,19 @@ class SecurityBuffer : public Nan::ObjectWrap {
     SecBuffer sec_buffer;
 
     // Has instance check
-    static inline bool HasInstance(Handle<Value> val) {
+    static inline bool HasInstance(Local<Value> val) {
       if (!val->IsObject()) return false;
       Local<Object> obj = val->ToObject();
       return Nan::New(constructor_template)->HasInstance(obj);
     };
 
     // Functions available from V8
-    static void Initialize(Handle<Object> target);    
+    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(ToBuffer);
 
     // Constructor used for creating new Long objects from C++
     static Nan::Persistent<FunctionTemplate> constructor_template;
-    
+
   private:
     static NAN_METHOD(New);
 };

--- a/lib/win32/wrappers/security_buffer.h
+++ b/lib/win32/wrappers/security_buffer.h
@@ -10,12 +10,12 @@
 #include <winsock2.h>
 #include <windows.h>
 #include <sspi.h>
-#include "nan.h"
+#include <nan.h>
 
 using namespace v8;
 using namespace node;
 
-class SecurityBuffer : public ObjectWrap {  
+class SecurityBuffer : public Nan::ObjectWrap {  
   public:    
     SecurityBuffer(uint32_t security_type, size_t size);
     SecurityBuffer(uint32_t security_type, size_t size, void *data);
@@ -31,7 +31,7 @@ class SecurityBuffer : public ObjectWrap {
     static inline bool HasInstance(Handle<Value> val) {
       if (!val->IsObject()) return false;
       Local<Object> obj = val->ToObject();
-      return NanNew(constructor_template)->HasInstance(obj);
+      return Nan::New(constructor_template)->HasInstance(obj);
     };
 
     // Functions available from V8
@@ -39,7 +39,7 @@ class SecurityBuffer : public ObjectWrap {
     static NAN_METHOD(ToBuffer);
 
     // Constructor used for creating new Long objects from C++
-    static Persistent<FunctionTemplate> constructor_template;
+    static Nan::Persistent<FunctionTemplate> constructor_template;
     
   private:
     static NAN_METHOD(New);

--- a/lib/win32/wrappers/security_buffer_descriptor.cc
+++ b/lib/win32/wrappers/security_buffer_descriptor.cc
@@ -40,7 +40,7 @@ SecurityBufferDescriptor::SecurityBufferDescriptor(const Nan::Persistent<Array>&
   } else {
     this->secBufferDesc.pBuffers = new SecBuffer[arrayObject->Length()];
     this->secBufferDesc.cBuffers = arrayObject->Length();
-    
+
     // Assign the buffers
     for(uint32_t i = 0; i < arrayObject->Length(); i++) {
       security_obj = Nan::ObjectWrap::Unwrap<SecurityBuffer>(arrayObject->Get(i)->ToObject());
@@ -98,7 +98,6 @@ char *SecurityBufferDescriptor::toBuffer() {
 }
 
 NAN_METHOD(SecurityBufferDescriptor::New) {
-  Nan::HandleScope scope;
   SecurityBufferDescriptor *security_obj;
   Nan::Persistent<Array> arrayObject;
 
@@ -109,7 +108,7 @@ NAN_METHOD(SecurityBufferDescriptor::New) {
     return Nan::ThrowError("There must be 1 argument passed in where the first argument is a [int32 or an Array of SecurityBuffers]");
 
   if(info[0]->IsArray()) {
-    Handle<Array> array = Handle<Array>::Cast(info[0]);
+    Local<Array> array = Local<Array>::Cast(info[0]);
     // Iterate over all items and ensure we the right type
     for(uint32_t i = 0; i < array->Length(); i++) {
       if(!SecurityBuffer::HasInstance(array->Get(i))) {
@@ -122,7 +121,7 @@ NAN_METHOD(SecurityBufferDescriptor::New) {
   if(info[0]->IsInt32()) {
     // Create new SecurityBuffer instance
     Local<Value> argv[] = {Nan::New<Int32>(0x02), info[0]};
-    Handle<Value> security_buffer = Nan::New(SecurityBuffer::constructor_template)->GetFunction()->NewInstance(2, argv);
+    Local<Value> security_buffer = Nan::New(SecurityBuffer::constructor_template)->GetFunction()->NewInstance(2, argv);
     // Create a new array
     Local<Array> array = Nan::New<Array>(1);
     // Set the first value
@@ -137,7 +136,7 @@ NAN_METHOD(SecurityBufferDescriptor::New) {
   } else {
     // Create a persistent handler
     Nan::Persistent<Array> persistenHandler;
-    persistenHandler.Reset(Handle<Array>::Cast(info[0]));
+    persistenHandler.Reset(Local<Array>::Cast(info[0]));
     // Create a descriptor
     security_obj = new SecurityBufferDescriptor(persistenHandler);
   }
@@ -149,8 +148,6 @@ NAN_METHOD(SecurityBufferDescriptor::New) {
 }
 
 NAN_METHOD(SecurityBufferDescriptor::ToBuffer) {
-  Nan::HandleScope scope;
-
   // Unpack the Security Buffer object
   SecurityBufferDescriptor *security_obj = Nan::ObjectWrap::Unwrap<SecurityBufferDescriptor>(info.This());
 
@@ -165,7 +162,7 @@ NAN_METHOD(SecurityBufferDescriptor::ToBuffer) {
   info.GetReturnValue().Set(buffer);
 }
 
-void SecurityBufferDescriptor::Initialize(Handle<Object> target) {
+void SecurityBufferDescriptor::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   // Grab the scope of the call from Node
   Nan::HandleScope scope;
 

--- a/lib/win32/wrappers/security_buffer_descriptor.cc
+++ b/lib/win32/wrappers/security_buffer_descriptor.cc
@@ -15,15 +15,15 @@
 #include "security_buffer_descriptor.h"
 #include "security_buffer.h"
 
-Persistent<FunctionTemplate> SecurityBufferDescriptor::constructor_template;
+Nan::Persistent<FunctionTemplate> SecurityBufferDescriptor::constructor_template;
 
-SecurityBufferDescriptor::SecurityBufferDescriptor() : ObjectWrap() {
+SecurityBufferDescriptor::SecurityBufferDescriptor() : Nan::ObjectWrap() {
 }
 
-SecurityBufferDescriptor::SecurityBufferDescriptor(const Persistent<Array>& arrayObjectPersistent) : ObjectWrap() {
+SecurityBufferDescriptor::SecurityBufferDescriptor(const Nan::Persistent<Array>& arrayObjectPersistent) : Nan::ObjectWrap() {
   SecurityBuffer *security_obj = NULL;
   // Get the Local value
-  Local<Array> arrayObject = NanNew(arrayObjectPersistent);
+  Local<Array> arrayObject = Nan::New(arrayObjectPersistent);
 
   // Safe reference to array
   this->arrayObject = arrayObject;
@@ -34,7 +34,7 @@ SecurityBufferDescriptor::SecurityBufferDescriptor(const Persistent<Array>& arra
 
   if(arrayObject->Length() == 1) {
     // Unwrap  the buffer
-    security_obj = ObjectWrap::Unwrap<SecurityBuffer>(arrayObject->Get(0)->ToObject());
+    security_obj = Nan::ObjectWrap::Unwrap<SecurityBuffer>(arrayObject->Get(0)->ToObject());
     // Assign the buffer
     this->secBufferDesc.pBuffers = &security_obj->sec_buffer;
   } else {
@@ -43,7 +43,7 @@ SecurityBufferDescriptor::SecurityBufferDescriptor(const Persistent<Array>& arra
     
     // Assign the buffers
     for(uint32_t i = 0; i < arrayObject->Length(); i++) {
-      security_obj = ObjectWrap::Unwrap<SecurityBuffer>(arrayObject->Get(i)->ToObject());
+      security_obj = Nan::ObjectWrap::Unwrap<SecurityBuffer>(arrayObject->Get(i)->ToObject());
       this->secBufferDesc.pBuffers[i].BufferType = security_obj->sec_buffer.BufferType;
       this->secBufferDesc.pBuffers[i].pvBuffer = security_obj->sec_buffer.pvBuffer;
       this->secBufferDesc.pBuffers[i].cbBuffer = security_obj->sec_buffer.cbBuffer;
@@ -58,7 +58,7 @@ size_t SecurityBufferDescriptor::bufferSize() {
   SecurityBuffer *security_obj = NULL;
 
   if(this->secBufferDesc.cBuffers == 1) {
-    security_obj = ObjectWrap::Unwrap<SecurityBuffer>(arrayObject->Get(0)->ToObject());
+    security_obj = Nan::ObjectWrap::Unwrap<SecurityBuffer>(arrayObject->Get(0)->ToObject());
     return security_obj->size;
   } else {
     int bytesToAllocate = 0;
@@ -77,7 +77,7 @@ char *SecurityBufferDescriptor::toBuffer() {
   char *data = NULL;
 
   if(this->secBufferDesc.cBuffers == 1) {
-    security_obj = ObjectWrap::Unwrap<SecurityBuffer>(arrayObject->Get(0)->ToObject());
+    security_obj = Nan::ObjectWrap::Unwrap<SecurityBuffer>(arrayObject->Get(0)->ToObject());
     data = (char *)malloc(security_obj->size * sizeof(char));
     memcpy(data, security_obj->data, security_obj->size);
   } else {
@@ -98,88 +98,88 @@ char *SecurityBufferDescriptor::toBuffer() {
 }
 
 NAN_METHOD(SecurityBufferDescriptor::New) {
-  NanScope();
+  Nan::HandleScope scope;
   SecurityBufferDescriptor *security_obj;
-  Persistent<Array> arrayObject;
+  Nan::Persistent<Array> arrayObject;
 
-  if(args.Length() != 1)
-    return NanThrowError("There must be 1 argument passed in where the first argument is a [int32 or an Array of SecurityBuffers]");
+  if(info.Length() != 1)
+    return Nan::ThrowError("There must be 1 argument passed in where the first argument is a [int32 or an Array of SecurityBuffers]");
 
-  if(!args[0]->IsInt32() && !args[0]->IsArray())
-    return NanThrowError("There must be 1 argument passed in where the first argument is a [int32 or an Array of SecurityBuffers]");
+  if(!info[0]->IsInt32() && !info[0]->IsArray())
+    return Nan::ThrowError("There must be 1 argument passed in where the first argument is a [int32 or an Array of SecurityBuffers]");
 
-  if(args[0]->IsArray()) {
-    Handle<Array> array = Handle<Array>::Cast(args[0]);
+  if(info[0]->IsArray()) {
+    Handle<Array> array = Handle<Array>::Cast(info[0]);
     // Iterate over all items and ensure we the right type
     for(uint32_t i = 0; i < array->Length(); i++) {
       if(!SecurityBuffer::HasInstance(array->Get(i))) {
-        return NanThrowError("There must be 1 argument passed in where the first argument is a [int32 or an Array of SecurityBuffers]");
+        return Nan::ThrowError("There must be 1 argument passed in where the first argument is a [int32 or an Array of SecurityBuffers]");
       }
     }
   }
 
   // We have a single integer
-  if(args[0]->IsInt32()) {
+  if(info[0]->IsInt32()) {
     // Create new SecurityBuffer instance
-    Local<Value> argv[] = {NanNew<Int32>(0x02), args[0]};
-    Handle<Value> security_buffer = NanNew(SecurityBuffer::constructor_template)->GetFunction()->NewInstance(2, argv);
+    Local<Value> argv[] = {Nan::New<Int32>(0x02), info[0]};
+    Handle<Value> security_buffer = Nan::New(SecurityBuffer::constructor_template)->GetFunction()->NewInstance(2, argv);
     // Create a new array
-    Local<Array> array = NanNew<Array>(1);
+    Local<Array> array = Nan::New<Array>(1);
     // Set the first value
     array->Set(0, security_buffer);
 
     // Create persistent handle
-    Persistent<Array> persistenHandler;
-    NanAssignPersistent(persistenHandler, array);
+    Nan::Persistent<Array> persistenHandler;
+    persistenHandler.Reset(array);
 
     // Create descriptor
     security_obj = new SecurityBufferDescriptor(persistenHandler);
   } else {
     // Create a persistent handler
-    Persistent<Array> persistenHandler;
-    NanAssignPersistent(persistenHandler, Handle<Array>::Cast(args[0]));
+    Nan::Persistent<Array> persistenHandler;
+    persistenHandler.Reset(Handle<Array>::Cast(info[0]));
     // Create a descriptor
     security_obj = new SecurityBufferDescriptor(persistenHandler);
   }
 
   // Wrap it
-  security_obj->Wrap(args.This());
+  security_obj->Wrap(info.This());
   // Return the object
-  NanReturnValue(args.This());
+  info.GetReturnValue().Set(info.This());
 }
 
 NAN_METHOD(SecurityBufferDescriptor::ToBuffer) {
-  NanScope();
+  Nan::HandleScope scope;
 
   // Unpack the Security Buffer object
-  SecurityBufferDescriptor *security_obj = ObjectWrap::Unwrap<SecurityBufferDescriptor>(args.This());
+  SecurityBufferDescriptor *security_obj = Nan::ObjectWrap::Unwrap<SecurityBufferDescriptor>(info.This());
 
   // Get the buffer
   char *buffer_data = security_obj->toBuffer();
   size_t buffer_size = security_obj->bufferSize();
 
   // Create a Buffer
-  Local<Object> buffer = NanNewBufferHandle(buffer_data, (uint32_t)buffer_size);
+  Local<Object> buffer = Nan::CopyBuffer(buffer_data, (uint32_t)buffer_size).ToLocalChecked();
 
   // Return the buffer
-  NanReturnValue(buffer);
+  info.GetReturnValue().Set(buffer);
 }
 
 void SecurityBufferDescriptor::Initialize(Handle<Object> target) {
   // Grab the scope of the call from Node
-  NanScope();
+  Nan::HandleScope scope;
 
   // Define a new function template
-  Local<FunctionTemplate> t = NanNew<FunctionTemplate>(New);
+  Local<FunctionTemplate> t = Nan::New<FunctionTemplate>(New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(NanNew<String>("SecurityBufferDescriptor"));
+  t->SetClassName(Nan::New<String>("SecurityBufferDescriptor").ToLocalChecked());
 
   // Class methods
-  NODE_SET_PROTOTYPE_METHOD(t, "toBuffer", ToBuffer);
+  Nan::SetPrototypeMethod(t, "toBuffer", ToBuffer);
 
   // Set persistent
-  NanAssignPersistent(constructor_template, t);
+  constructor_template.Reset(t);
 
   // Set the symbol
-  target->ForceSet(NanNew<String>("SecurityBufferDescriptor"), t->GetFunction());
+  target->ForceSet(Nan::New<String>("SecurityBufferDescriptor").ToLocalChecked(), t->GetFunction());
 }

--- a/lib/win32/wrappers/security_buffer_descriptor.h
+++ b/lib/win32/wrappers/security_buffer_descriptor.h
@@ -8,25 +8,25 @@
 #include <WinSock2.h>
 #include <windows.h>
 #include <sspi.h>
-#include "nan.h"
+#include <nan.h>
 
 using namespace v8;
 using namespace node;
 
-class SecurityBufferDescriptor : public ObjectWrap {  
+class SecurityBufferDescriptor : public Nan::ObjectWrap {  
   public:    
     Local<Array> arrayObject;
     SecBufferDesc secBufferDesc;
     
     SecurityBufferDescriptor();
-    SecurityBufferDescriptor(const Persistent<Array>& arrayObjectPersistent);
+    SecurityBufferDescriptor(const Nan::Persistent<Array>& arrayObjectPersistent);
     ~SecurityBufferDescriptor();    
 
     // Has instance check
     static inline bool HasInstance(Handle<Value> val) {
       if (!val->IsObject()) return false;
       Local<Object> obj = val->ToObject();
-      return NanNew(constructor_template)->HasInstance(obj);
+      return Nan::New(constructor_template)->HasInstance(obj);
     };
 
     char *toBuffer();
@@ -37,7 +37,7 @@ class SecurityBufferDescriptor : public ObjectWrap {
     static NAN_METHOD(ToBuffer);
 
     // Constructor used for creating new Long objects from C++
-    static Persistent<FunctionTemplate> constructor_template;
+    static Nan::Persistent<FunctionTemplate> constructor_template;
     
   private:
     static NAN_METHOD(New);

--- a/lib/win32/wrappers/security_buffer_descriptor.h
+++ b/lib/win32/wrappers/security_buffer_descriptor.h
@@ -13,17 +13,17 @@
 using namespace v8;
 using namespace node;
 
-class SecurityBufferDescriptor : public Nan::ObjectWrap {  
-  public:    
+class SecurityBufferDescriptor : public Nan::ObjectWrap {
+  public:
     Local<Array> arrayObject;
     SecBufferDesc secBufferDesc;
-    
+
     SecurityBufferDescriptor();
     SecurityBufferDescriptor(const Nan::Persistent<Array>& arrayObjectPersistent);
-    ~SecurityBufferDescriptor();    
+    ~SecurityBufferDescriptor();
 
     // Has instance check
-    static inline bool HasInstance(Handle<Value> val) {
+    static inline bool HasInstance(Local<Value> val) {
       if (!val->IsObject()) return false;
       Local<Object> obj = val->ToObject();
       return Nan::New(constructor_template)->HasInstance(obj);
@@ -33,12 +33,12 @@ class SecurityBufferDescriptor : public Nan::ObjectWrap {
     size_t bufferSize();
 
     // Functions available from V8
-    static void Initialize(Handle<Object> target);    
+    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(ToBuffer);
 
     // Constructor used for creating new Long objects from C++
     static Nan::Persistent<FunctionTemplate> constructor_template;
-    
+
   private:
     static NAN_METHOD(New);
 };

--- a/lib/win32/wrappers/security_context.cc
+++ b/lib/win32/wrappers/security_context.cc
@@ -54,9 +54,9 @@ static void After(uv_work_t* work_req) {
     }
   } else {
     // // Map the data
-    Handle<Value> result = worker->mapper(worker);
+    Local<Value> result = worker->mapper(worker);
     // Set up the callback with a null first
-    Handle<Value> info[2] = { Nan::Null(), result};
+    Local<Value> info[2] = { Nan::Null(), result};
     // Wrap the callback function call in a TryCatch so that we can call
     // node's FatalException afterwards. This makes it possible to catch
     // the exception from JavaScript land using the
@@ -89,8 +89,6 @@ SecurityContext::~SecurityContext() {
 }
 
 NAN_METHOD(SecurityContext::New) {
-  Nan::HandleScope scope;
-
   PSecurityFunctionTable pSecurityInterface = NULL;
   DWORD dwNumOfPkgs;
   SECURITY_STATUS status;
@@ -101,7 +99,7 @@ NAN_METHOD(SecurityContext::New) {
   pSecurityInterface = _ssip_InitSecurityInterface();
   // Call the security interface
   status = (*pSecurityInterface->EnumerateSecurityPackages)(
-                                                    &dwNumOfPkgs, 
+                                                    &dwNumOfPkgs,
                                                     &security_obj->m_PkgInfo);
   if(status != SEC_E_OK) {
     printf(TEXT("Failed in retrieving security packages, Error: %x"), GetLastError());
@@ -134,7 +132,7 @@ static void _initializeContext(Worker *worker) {
   SecBufferDesc ibd, obd;
   SecBuffer ib, ob;
 
-  // 
+  //
   // Prepare data structure for returned data from SSPI
   ob.BufferType = SECBUFFER_TOKEN;
   ob.cbBuffer = call->context->m_PkgInfo->cbMaxToken;
@@ -155,7 +153,7 @@ static void _initializeContext(Worker *worker) {
     // prepare buffer description
     ibd.cBuffers  = 1;
     ibd.ulVersion = SECBUFFER_VERSION;
-    ibd.pBuffers  = &ib;    
+    ibd.pBuffers  = &ib;
   }
 
   // Perform initialization step
@@ -175,7 +173,7 @@ static void _initializeContext(Worker *worker) {
   );
 
   // If we have a ok or continue let's prepare the result
-  if(status == SEC_E_OK 
+  if(status == SEC_E_OK
     || status == SEC_I_COMPLETE_NEEDED
     || status == SEC_I_CONTINUE_NEEDED
     || status == SEC_I_COMPLETE_AND_CONTINUE
@@ -237,7 +235,7 @@ static void _initializeContext(Worker *worker) {
   if(call->service_principal_name_str != NULL) free(call->service_principal_name_str);
 }
 
-static Handle<Value> _map_initializeContext(Worker *worker) {
+static Local<Value> _map_initializeContext(Worker *worker) {
   // Unwrap the security context
   SecurityContext *context = (SecurityContext *)worker->return_value;
   // Return the value
@@ -245,7 +243,6 @@ static Handle<Value> _map_initializeContext(Worker *worker) {
 }
 
 NAN_METHOD(SecurityContext::InitializeContext) {
-  Nan::HandleScope scope;
   char *service_principal_name_str = NULL, *input_str = NULL, *decoded_input_str = NULL;
   int decoded_input_str_length = NULL;
   // Store reference to security credentials
@@ -325,7 +322,6 @@ NAN_METHOD(SecurityContext::InitializeContext) {
 }
 
 NAN_GETTER(SecurityContext::PayloadGetter) {
-  Nan::HandleScope scope;
   // Unpack the context object
   SecurityContext *context = Nan::ObjectWrap::Unwrap<SecurityContext>(info.This());
   // Return the low bits
@@ -333,7 +329,6 @@ NAN_GETTER(SecurityContext::PayloadGetter) {
 }
 
 NAN_GETTER(SecurityContext::HasContextGetter) {
-  Nan::HandleScope scope;
   // Unpack the context object
   SecurityContext *context = Nan::ObjectWrap::Unwrap<SecurityContext>(info.This());
   // Return the low bits
@@ -362,7 +357,7 @@ static void _initializeContextStep(Worker *worker) {
   SecBufferDesc ibd, obd;
   SecBuffer ib, ob;
 
-  // 
+  //
   // Prepare data structure for returned data from SSPI
   ob.BufferType = SECBUFFER_TOKEN;
   ob.cbBuffer = context->m_PkgInfo->cbMaxToken;
@@ -383,7 +378,7 @@ static void _initializeContextStep(Worker *worker) {
     // prepare buffer description
     ibd.cBuffers  = 1;
     ibd.ulVersion = SECBUFFER_VERSION;
-    ibd.pBuffers  = &ib;    
+    ibd.pBuffers  = &ib;
   }
 
   // Perform initialization step
@@ -403,7 +398,7 @@ static void _initializeContextStep(Worker *worker) {
   );
 
   // If we have a ok or continue let's prepare the result
-  if(status == SEC_E_OK 
+  if(status == SEC_E_OK
     || status == SEC_I_COMPLETE_NEEDED
     || status == SEC_I_CONTINUE_NEEDED
     || status == SEC_I_COMPLETE_AND_CONTINUE
@@ -424,7 +419,7 @@ static void _initializeContextStep(Worker *worker) {
   if(call->service_principal_name_str != NULL) free(call->service_principal_name_str);
 }
 
-static Handle<Value> _map_initializeContextStep(Worker *worker) {
+static Local<Value> _map_initializeContextStep(Worker *worker) {
   // Unwrap the security context
   SecurityContext *context = (SecurityContext *)worker->return_value;
   // Return the value
@@ -432,8 +427,6 @@ static Handle<Value> _map_initializeContextStep(Worker *worker) {
 }
 
 NAN_METHOD(SecurityContext::InitalizeStep) {
-  Nan::HandleScope scope;
-
   char *service_principal_name_str = NULL, *input_str = NULL, *decoded_input_str = NULL;
   int decoded_input_str_length = NULL;
 
@@ -526,7 +519,7 @@ static void _encryptMessage(Worker *worker) {
 
   // We've got ok
   if(status == SEC_E_OK) {
-    int bytesToAllocate = (int)descriptor->bufferSize();    
+    int bytesToAllocate = (int)descriptor->bufferSize();
     // Free up existing payload
     if(context->payload != NULL) free(context->payload);
     // Save the payload
@@ -541,7 +534,7 @@ static void _encryptMessage(Worker *worker) {
   }
 }
 
-static Handle<Value> _map_encryptMessage(Worker *worker) {
+static Local<Value> _map_encryptMessage(Worker *worker) {
   // Unwrap the security context
   SecurityContext *context = (SecurityContext *)worker->return_value;
   // Return the value
@@ -549,16 +542,14 @@ static Handle<Value> _map_encryptMessage(Worker *worker) {
 }
 
 NAN_METHOD(SecurityContext::EncryptMessage) {
-  Nan::HandleScope scope;
-
   if(info.Length() != 3)
-    return Nan::ThrowError("EncryptMessage takes an instance of SecurityBufferDescriptor, an integer flag and a callback function");  
+    return Nan::ThrowError("EncryptMessage takes an instance of SecurityBufferDescriptor, an integer flag and a callback function");
   if(!SecurityBufferDescriptor::HasInstance(info[0]))
-    return Nan::ThrowError("EncryptMessage takes an instance of SecurityBufferDescriptor, an integer flag and a callback function");  
+    return Nan::ThrowError("EncryptMessage takes an instance of SecurityBufferDescriptor, an integer flag and a callback function");
   if(!info[1]->IsUint32())
-    return Nan::ThrowError("EncryptMessage takes an instance of SecurityBufferDescriptor, an integer flag and a callback function");  
+    return Nan::ThrowError("EncryptMessage takes an instance of SecurityBufferDescriptor, an integer flag and a callback function");
   if(!info[2]->IsFunction())
-    return Nan::ThrowError("EncryptMessage takes an instance of SecurityBufferDescriptor, an integer flag and a callback function");  
+    return Nan::ThrowError("EncryptMessage takes an instance of SecurityBufferDescriptor, an integer flag and a callback function");
 
   // Unpack the security context
   SecurityContext *security_context = Nan::ObjectWrap::Unwrap<SecurityContext>(info.This());
@@ -602,7 +593,7 @@ typedef struct SecurityContextDecryptMessageCall {
 static void _decryptMessage(Worker *worker) {
   unsigned long quality = 0;
   SECURITY_STATUS status;
-  
+
   // Unpack parameters
   SecurityContextDecryptMessageCall *call = (SecurityContextDecryptMessageCall *)worker->parameters;
   SecurityContext *context = call->context;
@@ -618,7 +609,7 @@ static void _decryptMessage(Worker *worker) {
 
   // We've got ok
   if(status == SEC_E_OK) {
-    int bytesToAllocate = (int)descriptor->bufferSize();    
+    int bytesToAllocate = (int)descriptor->bufferSize();
     // Free up existing payload
     if(context->payload != NULL) free(context->payload);
     // Save the payload
@@ -633,7 +624,7 @@ static void _decryptMessage(Worker *worker) {
   }
 }
 
-static Handle<Value> _map_decryptMessage(Worker *worker) {
+static Local<Value> _map_decryptMessage(Worker *worker) {
   // Unwrap the security context
   SecurityContext *context = (SecurityContext *)worker->return_value;
   // Return the value
@@ -641,8 +632,6 @@ static Handle<Value> _map_decryptMessage(Worker *worker) {
 }
 
 NAN_METHOD(SecurityContext::DecryptMessage) {
-  Nan::HandleScope scope;
-
   if(info.Length() != 2)
     return Nan::ThrowError("DecryptMessage takes an instance of SecurityBufferDescriptor and a callback function");
   if(!SecurityBufferDescriptor::HasInstance(info[0]))
@@ -690,7 +679,7 @@ static void _queryContextAttributes(Worker *worker) {
   SECURITY_STATUS status;
 
   // Cast to data structure
-  SecurityContextQueryContextAttributesCall *call = (SecurityContextQueryContextAttributesCall *)worker->parameters;  
+  SecurityContextQueryContextAttributesCall *call = (SecurityContextQueryContextAttributesCall *)worker->parameters;
 
   // Allocate some space
   SecPkgContext_Sizes *sizes = (SecPkgContext_Sizes *)calloc(1, sizeof(SecPkgContext_Sizes));
@@ -699,8 +688,8 @@ static void _queryContextAttributes(Worker *worker) {
     &call->context->m_Context,
     call->attribute,
     sizes
-  );  
-  
+  );
+
   if(status == SEC_E_OK) {
     worker->return_code = status;
     worker->return_value = sizes;
@@ -711,9 +700,9 @@ static void _queryContextAttributes(Worker *worker) {
   }
 }
 
-static Handle<Value> _map_queryContextAttributes(Worker *worker) {
+static Local<Value> _map_queryContextAttributes(Worker *worker) {
   // Cast to data structure
-  SecurityContextQueryContextAttributesCall *call = (SecurityContextQueryContextAttributesCall *)worker->parameters;  
+  SecurityContextQueryContextAttributesCall *call = (SecurityContextQueryContextAttributesCall *)worker->parameters;
   // Unpack the attribute
   uint32_t attribute = call->attribute;
 
@@ -734,8 +723,6 @@ static Handle<Value> _map_queryContextAttributes(Worker *worker) {
 }
 
 NAN_METHOD(SecurityContext::QueryContextAttributes) {
-  Nan::HandleScope scope;
-
   if(info.Length() != 2)
     return Nan::ThrowError("QueryContextAttributes method takes a an integer Attribute specifier and a callback function");
   if(!info[0]->IsInt32())
@@ -747,10 +734,10 @@ NAN_METHOD(SecurityContext::QueryContextAttributes) {
   SecurityContext *security_context = Nan::ObjectWrap::Unwrap<SecurityContext>(info.This());
 
   // Unpack the int value
-  uint32_t attribute = info[0]->ToInt32()->Value();  
+  uint32_t attribute = info[0]->ToInt32()->Value();
 
   // Check that we have a supported attribute
-  if(attribute != SECPKG_ATTR_SIZES) 
+  if(attribute != SECPKG_ATTR_SIZES)
     return Nan::ThrowError("QueryContextAttributes only supports the SECPKG_ATTR_SIZES attribute");
 
   // Create call structure
@@ -777,7 +764,7 @@ NAN_METHOD(SecurityContext::QueryContextAttributes) {
   info.GetReturnValue().Set(Nan::Undefined());
 }
 
-void SecurityContext::Initialize(Handle<Object> target) {
+void SecurityContext(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   // Grab the scope of the call from Node
   Nan::HandleScope scope;
 
@@ -818,49 +805,49 @@ static LPSTR DisplaySECError(DWORD ErrCode) {
       break;
 
     case SEC_E_CRYPTO_SYSTEM_INVALID:
-      pszName = "SEC_E_CRYPTO_SYSTEM_INVALID - The cipher chosen for the security context is not supported. Used with the Digest SSP."; 
+      pszName = "SEC_E_CRYPTO_SYSTEM_INVALID - The cipher chosen for the security context is not supported. Used with the Digest SSP.";
       break;
     case SEC_E_INCOMPLETE_MESSAGE:
-      pszName = "SEC_E_INCOMPLETE_MESSAGE - The data in the input buffer is incomplete. The application needs to read more data from the server and call DecryptMessageSync (General) again."; 
+      pszName = "SEC_E_INCOMPLETE_MESSAGE - The data in the input buffer is incomplete. The application needs to read more data from the server and call DecryptMessageSync (General) again.";
       break;
 
     case SEC_E_INVALID_HANDLE:
-      pszName = "SEC_E_INVALID_HANDLE - A context handle that is not valid was specified in the phContext parameter. Used with the Digest and Schannel SSPs."; 
+      pszName = "SEC_E_INVALID_HANDLE - A context handle that is not valid was specified in the phContext parameter. Used with the Digest and Schannel SSPs.";
       break;
 
     case SEC_E_INVALID_TOKEN:
-      pszName = "SEC_E_INVALID_TOKEN - The buffers are of the wrong type or no buffer of type SECBUFFER_DATA was found. Used with the Schannel SSP."; 
+      pszName = "SEC_E_INVALID_TOKEN - The buffers are of the wrong type or no buffer of type SECBUFFER_DATA was found. Used with the Schannel SSP.";
       break;
-        
+
     case SEC_E_MESSAGE_ALTERED:
-      pszName = "SEC_E_MESSAGE_ALTERED - The message has been altered. Used with the Digest and Schannel SSPs."; 
+      pszName = "SEC_E_MESSAGE_ALTERED - The message has been altered. Used with the Digest and Schannel SSPs.";
       break;
-        
+
     case SEC_E_OUT_OF_SEQUENCE:
-      pszName = "SEC_E_OUT_OF_SEQUENCE - The message was not received in the correct sequence."; 
+      pszName = "SEC_E_OUT_OF_SEQUENCE - The message was not received in the correct sequence.";
       break;
-        
+
     case SEC_E_QOP_NOT_SUPPORTED:
-      pszName = "SEC_E_QOP_NOT_SUPPORTED - Neither confidentiality nor integrity are supported by the security context. Used with the Digest SSP."; 
+      pszName = "SEC_E_QOP_NOT_SUPPORTED - Neither confidentiality nor integrity are supported by the security context. Used with the Digest SSP.";
       break;
-        
+
     case SEC_I_CONTEXT_EXPIRED:
-      pszName = "SEC_I_CONTEXT_EXPIRED - The message sender has finished using the connection and has initiated a shutdown."; 
+      pszName = "SEC_I_CONTEXT_EXPIRED - The message sender has finished using the connection and has initiated a shutdown.";
       break;
-        
+
     case SEC_I_RENEGOTIATE:
-      pszName = "SEC_I_RENEGOTIATE - The remote party requires a new handshake sequence or the application has just initiated a shutdown."; 
+      pszName = "SEC_I_RENEGOTIATE - The remote party requires a new handshake sequence or the application has just initiated a shutdown.";
       break;
-        
+
     case SEC_E_ENCRYPT_FAILURE:
-      pszName = "SEC_E_ENCRYPT_FAILURE - The specified data could not be encrypted."; 
+      pszName = "SEC_E_ENCRYPT_FAILURE - The specified data could not be encrypted.";
       break;
-        
+
     case SEC_E_DECRYPT_FAILURE:
-      pszName = "SEC_E_DECRYPT_FAILURE - The specified data could not be decrypted."; 
+      pszName = "SEC_E_DECRYPT_FAILURE - The specified data could not be decrypted.";
       break;
     case -1:
-      pszName = "Failed to load security.dll library"; 
+      pszName = "Failed to load security.dll library";
       break;
   }
 

--- a/lib/win32/wrappers/security_context.cc
+++ b/lib/win32/wrappers/security_context.cc
@@ -799,8 +799,8 @@ void SecurityContext::Initialize(Handle<Object> target) {
   Local<ObjectTemplate> proto = t->PrototypeTemplate();
 
   // Getter for the response
-  proto->SetAccessor(Nan::New<String>("payload").ToLocalChecked(), SecurityContext::PayloadGetter);
-  proto->SetAccessor(Nan::New<String>("hasContext").ToLocalChecked(), SecurityContext::HasContextGetter);
+  Nan::SetAccessor(proto, Nan::New<String>("payload").ToLocalChecked(), SecurityContext::PayloadGetter);
+  Nan::SetAccessor(proto, Nan::New<String>("hasContext").ToLocalChecked(), SecurityContext::HasContextGetter);
 
   // Set persistent
   constructor_template.Reset(t);

--- a/lib/win32/wrappers/security_context.cc
+++ b/lib/win32/wrappers/security_context.cc
@@ -787,7 +787,7 @@ void SecurityContext::Initialize(Handle<Object> target) {
   t->SetClassName(Nan::New<String>("SecurityContext").ToLocalChecked());
 
   // Class methods
-  NODE_SET_METHOD(t, "initialize", InitializeContext);
+  Nan::SetMethod(t, "initialize", InitializeContext);
 
   // Set up method for the instance
   Nan::SetPrototypeMethod(t, "initialize", InitalizeStep);

--- a/lib/win32/wrappers/security_context.h
+++ b/lib/win32/wrappers/security_context.h
@@ -13,7 +13,7 @@
 #include <tchar.h>
 #include "security_credentials.h"
 #include "../worker.h"
-#include "nan.h"
+#include <nan.h>
 
 extern "C" {
   #include "../kerberos_sspi.h"
@@ -23,7 +23,7 @@ extern "C" {
 using namespace v8;
 using namespace node;
 
-class SecurityContext : public ObjectWrap {  
+class SecurityContext : public Nan::ObjectWrap {  
   public:    
     SecurityContext();
     ~SecurityContext();    
@@ -47,7 +47,7 @@ class SecurityContext : public ObjectWrap {
     static inline bool HasInstance(Handle<Value> val) {
       if (!val->IsObject()) return false;
       Local<Object> obj = val->ToObject();
-      return NanNew(constructor_template)->HasInstance(obj);
+      return Nan::New(constructor_template)->HasInstance(obj);
     };
 
     // Functions available from V8
@@ -64,7 +64,7 @@ class SecurityContext : public ObjectWrap {
     static NAN_GETTER(HasContextGetter);
 
     // Constructor used for creating new Long objects from C++
-    static Persistent<FunctionTemplate> constructor_template;
+    static Nan::Persistent<FunctionTemplate> constructor_template;
     
   private:
     // Create a new instance

--- a/lib/win32/wrappers/security_context.h
+++ b/lib/win32/wrappers/security_context.h
@@ -23,10 +23,10 @@ extern "C" {
 using namespace v8;
 using namespace node;
 
-class SecurityContext : public Nan::ObjectWrap {  
-  public:    
+class SecurityContext : public Nan::ObjectWrap {
+  public:
     SecurityContext();
-    ~SecurityContext();    
+    ~SecurityContext();
 
     // Security info package
     PSecPkgInfo m_PkgInfo;
@@ -44,14 +44,14 @@ class SecurityContext : public Nan::ObjectWrap {
     char *payload;
 
     // Has instance check
-    static inline bool HasInstance(Handle<Value> val) {
+    static inline bool HasInstance(Local<Value> val) {
       if (!val->IsObject()) return false;
       Local<Object> obj = val->ToObject();
       return Nan::New(constructor_template)->HasInstance(obj);
     };
 
     // Functions available from V8
-    static void Initialize(Handle<Object> target);
+    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(InitializeContext);
     static NAN_METHOD(InitalizeStep);
     static NAN_METHOD(DecryptMessage);
@@ -65,7 +65,7 @@ class SecurityContext : public Nan::ObjectWrap {
 
     // Constructor used for creating new Long objects from C++
     static Nan::Persistent<FunctionTemplate> constructor_template;
-    
+
   private:
     // Create a new instance
     static NAN_METHOD(New);

--- a/lib/win32/wrappers/security_credentials.cc
+++ b/lib/win32/wrappers/security_credentials.cc
@@ -27,7 +27,6 @@ SecurityCredentials::~SecurityCredentials() {
 }
 
 NAN_METHOD(SecurityCredentials::New) {
-  Nan::HandleScope scope;
   // Create security credentials instance
   SecurityCredentials *security_credentials = new SecurityCredentials();
   // Wrap it
@@ -53,7 +52,7 @@ static void _authSSPIAquire(Worker *worker) {
   SECURITY_STATUS status;
 
   // Unpack data
-  SecurityCredentialCall *call = (SecurityCredentialCall *)worker->parameters;  
+  SecurityCredentialCall *call = (SecurityCredentialCall *)worker->parameters;
 
   // // Unwrap the credentials
   // SecurityCredentials *security_credentials = (SecurityCredentials *)call->credentials;
@@ -76,7 +75,7 @@ static void _authSSPIAquire(Worker *worker) {
   if(call->password_str != NULL) {
     // Set up the password
     security_credentials->m_Identity.Password = USTR(_tcsdup(call->password_str));
-    security_credentials->m_Identity.PasswordLength = (unsigned long)_tcslen(call->password_str);    
+    security_credentials->m_Identity.PasswordLength = (unsigned long)_tcslen(call->password_str);
   }
 
   #ifdef _UNICODE
@@ -90,7 +89,7 @@ static void _authSSPIAquire(Worker *worker) {
     NULL,
     call->package_str,
     SECPKG_CRED_OUTBOUND,
-    NULL, 
+    NULL,
     call->password_str != NULL ? &security_credentials->m_Identity : NULL,
     NULL, NULL,
     &security_credentials->m_Credentials,
@@ -115,13 +114,11 @@ static void _authSSPIAquire(Worker *worker) {
   free(call);
 }
 
-static Handle<Value> _map_authSSPIAquire(Worker *worker) {
+static Local<Value> _map_authSSPIAquire(Worker *worker) {
   return Nan::Null();
 }
 
 NAN_METHOD(SecurityCredentials::Aquire) {
-  Nan::HandleScope scope;
-
   char *package_str = NULL, *username_str = NULL, *password_str = NULL, *domain_str = NULL;
   // Unpack the variables
   if(info.Length() != 2 && info.Length() != 3 && info.Length() != 4 && info.Length() != 5)
@@ -167,14 +164,14 @@ NAN_METHOD(SecurityCredentials::Aquire) {
   if(info.Length() == 3 || info.Length() == 4 || info.Length() == 5) {
     Local<String> password = info[2]->ToString();
     password_str = (char *)calloc(password->Utf8Length() + 1, sizeof(char));
-    password->WriteUtf8(password_str);    
+    password->WriteUtf8(password_str);
   }
 
   // If we have a domain
   if((info.Length() == 4 || info.Length() == 5) && info[3]->IsString()) {
     Local<String> domain = info[3]->ToString();
     domain_str = (char *)calloc(domain->Utf8Length() + 1, sizeof(char));
-    domain->WriteUtf8(domain_str);    
+    domain->WriteUtf8(domain_str);
   }
 
   // Allocate call structure
@@ -203,7 +200,7 @@ NAN_METHOD(SecurityCredentials::Aquire) {
   info.GetReturnValue().Set(Nan::Undefined());
 }
 
-void SecurityCredentials::Initialize(Handle<Object> target) {
+void SecurityCredentials::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   // Grab the scope of the call from Node
   Nan::HandleScope scope;
 
@@ -234,49 +231,49 @@ static LPSTR DisplaySECError(DWORD ErrCode) {
       break;
 
     case SEC_E_CRYPTO_SYSTEM_INVALID:
-      pszName = "SEC_E_CRYPTO_SYSTEM_INVALID - The cipher chosen for the security context is not supported. Used with the Digest SSP."; 
+      pszName = "SEC_E_CRYPTO_SYSTEM_INVALID - The cipher chosen for the security context is not supported. Used with the Digest SSP.";
       break;
     case SEC_E_INCOMPLETE_MESSAGE:
-      pszName = "SEC_E_INCOMPLETE_MESSAGE - The data in the input buffer is incomplete. The application needs to read more data from the server and call DecryptMessage (General) again."; 
+      pszName = "SEC_E_INCOMPLETE_MESSAGE - The data in the input buffer is incomplete. The application needs to read more data from the server and call DecryptMessage (General) again.";
       break;
 
     case SEC_E_INVALID_HANDLE:
-      pszName = "SEC_E_INVALID_HANDLE - A context handle that is not valid was specified in the phContext parameter. Used with the Digest and Schannel SSPs."; 
+      pszName = "SEC_E_INVALID_HANDLE - A context handle that is not valid was specified in the phContext parameter. Used with the Digest and Schannel SSPs.";
       break;
 
     case SEC_E_INVALID_TOKEN:
-      pszName = "SEC_E_INVALID_TOKEN - The buffers are of the wrong type or no buffer of type SECBUFFER_DATA was found. Used with the Schannel SSP."; 
+      pszName = "SEC_E_INVALID_TOKEN - The buffers are of the wrong type or no buffer of type SECBUFFER_DATA was found. Used with the Schannel SSP.";
       break;
-        
+
     case SEC_E_MESSAGE_ALTERED:
-      pszName = "SEC_E_MESSAGE_ALTERED - The message has been altered. Used with the Digest and Schannel SSPs."; 
+      pszName = "SEC_E_MESSAGE_ALTERED - The message has been altered. Used with the Digest and Schannel SSPs.";
       break;
-        
+
     case SEC_E_OUT_OF_SEQUENCE:
-      pszName = "SEC_E_OUT_OF_SEQUENCE - The message was not received in the correct sequence."; 
+      pszName = "SEC_E_OUT_OF_SEQUENCE - The message was not received in the correct sequence.";
       break;
-        
+
     case SEC_E_QOP_NOT_SUPPORTED:
-      pszName = "SEC_E_QOP_NOT_SUPPORTED - Neither confidentiality nor integrity are supported by the security context. Used with the Digest SSP."; 
+      pszName = "SEC_E_QOP_NOT_SUPPORTED - Neither confidentiality nor integrity are supported by the security context. Used with the Digest SSP.";
       break;
-        
+
     case SEC_I_CONTEXT_EXPIRED:
-      pszName = "SEC_I_CONTEXT_EXPIRED - The message sender has finished using the connection and has initiated a shutdown."; 
+      pszName = "SEC_I_CONTEXT_EXPIRED - The message sender has finished using the connection and has initiated a shutdown.";
       break;
-        
+
     case SEC_I_RENEGOTIATE:
-      pszName = "SEC_I_RENEGOTIATE - The remote party requires a new handshake sequence or the application has just initiated a shutdown."; 
+      pszName = "SEC_I_RENEGOTIATE - The remote party requires a new handshake sequence or the application has just initiated a shutdown.";
       break;
-        
+
     case SEC_E_ENCRYPT_FAILURE:
-      pszName = "SEC_E_ENCRYPT_FAILURE - The specified data could not be encrypted."; 
+      pszName = "SEC_E_ENCRYPT_FAILURE - The specified data could not be encrypted.";
       break;
-        
+
     case SEC_E_DECRYPT_FAILURE:
-      pszName = "SEC_E_DECRYPT_FAILURE - The specified data could not be decrypted."; 
+      pszName = "SEC_E_DECRYPT_FAILURE - The specified data could not be decrypted.";
       break;
     case -1:
-      pszName = "Failed to load security.dll library"; 
+      pszName = "Failed to load security.dll library";
       break;
 
   }
@@ -328,16 +325,16 @@ void SecurityCredentials::After(uv_work_t* work_req) {
     security_credentials->m_Credentials = return_value->m_Credentials;
     security_credentials->Expiration = return_value->Expiration;
     // Set up the callback with a null first
-    Handle<Value> info[2] = { Nan::Null(), result};
+    Local<Value> info[2] = { Nan::Null(), result};
     // Wrap the callback function call in a TryCatch so that we can call
     // node's FatalException afterwards. This makes it possible to catch
     // the exception from JavaScript land using the
     // process.on('uncaughtException') event.
     Nan::TryCatch try_catch;
-    
+
     // Call the callback
     worker->callback->Call(ARRAY_SIZE(info), info);
-    
+
     // If we have an exception handle it as a fatalexception
     if (try_catch.HasCaught()) {
       Nan::FatalException(try_catch);

--- a/lib/win32/wrappers/security_credentials.cc
+++ b/lib/win32/wrappers/security_credentials.cc
@@ -213,7 +213,7 @@ void SecurityCredentials::Initialize(Handle<Object> target) {
   t->SetClassName(Nan::New<String>("SecurityCredentials").ToLocalChecked());
 
   // Class methods
-  NODE_SET_METHOD(t, "aquire", Aquire);
+  Nan::SetMethod(t, "aquire", Aquire);
 
   // Set persistent
   constructor_template.Reset(t);

--- a/lib/win32/wrappers/security_credentials.cc
+++ b/lib/win32/wrappers/security_credentials.cc
@@ -18,22 +18,22 @@
 
 static LPSTR DisplaySECError(DWORD ErrCode);
 
-Persistent<FunctionTemplate> SecurityCredentials::constructor_template;
+Nan::Persistent<FunctionTemplate> SecurityCredentials::constructor_template;
 
-SecurityCredentials::SecurityCredentials() : ObjectWrap() {
+SecurityCredentials::SecurityCredentials() : Nan::ObjectWrap() {
 }
 
 SecurityCredentials::~SecurityCredentials() {
 }
 
 NAN_METHOD(SecurityCredentials::New) {
-  NanScope();
+  Nan::HandleScope scope;
   // Create security credentials instance
   SecurityCredentials *security_credentials = new SecurityCredentials();
   // Wrap it
-  security_credentials->Wrap(args.This());
+  security_credentials->Wrap(info.This());
   // Return the object
-  NanReturnValue(args.This());
+  info.GetReturnValue().Set(info.This());
 }
 
 // Call structs
@@ -116,63 +116,63 @@ static void _authSSPIAquire(Worker *worker) {
 }
 
 static Handle<Value> _map_authSSPIAquire(Worker *worker) {
-  return NanNull();
+  return Nan::Null();
 }
 
 NAN_METHOD(SecurityCredentials::Aquire) {
-  NanScope();
+  Nan::HandleScope scope;
 
   char *package_str = NULL, *username_str = NULL, *password_str = NULL, *domain_str = NULL;
   // Unpack the variables
-  if(args.Length() != 2 && args.Length() != 3 && args.Length() != 4 && args.Length() != 5)
-    return NanThrowError("Aquire must be called with either [package:string, username:string, [password:string, domain:string], callback:function]");
+  if(info.Length() != 2 && info.Length() != 3 && info.Length() != 4 && info.Length() != 5)
+    return Nan::ThrowError("Aquire must be called with either [package:string, username:string, [password:string, domain:string], callback:function]");
 
-  if(!args[0]->IsString())
-    return NanThrowError("Aquire must be called with either [package:string, username:string, [password:string, domain:string], callback:function]");
+  if(!info[0]->IsString())
+    return Nan::ThrowError("Aquire must be called with either [package:string, username:string, [password:string, domain:string], callback:function]");
 
-  if(!args[1]->IsString())
-    return NanThrowError("Aquire must be called with either [package:string, username:string, [password:string, domain:string], callback:function]");
+  if(!info[1]->IsString())
+    return Nan::ThrowError("Aquire must be called with either [package:string, username:string, [password:string, domain:string], callback:function]");
 
-  if(args.Length() == 3 && (!args[2]->IsString() && !args[2]->IsFunction()))
-    return NanThrowError("Aquire must be called with either [package:string, username:string, [password:string, domain:string], callback:function]");
+  if(info.Length() == 3 && (!info[2]->IsString() && !info[2]->IsFunction()))
+    return Nan::ThrowError("Aquire must be called with either [package:string, username:string, [password:string, domain:string], callback:function]");
 
-  if(args.Length() == 4 && (!args[3]->IsString() && !args[3]->IsUndefined() && !args[3]->IsNull()) && !args[3]->IsFunction())
-    return NanThrowError("Aquire must be called with either [package:string, username:string, [password:string, domain:string], callback:function]");
+  if(info.Length() == 4 && (!info[3]->IsString() && !info[3]->IsUndefined() && !info[3]->IsNull()) && !info[3]->IsFunction())
+    return Nan::ThrowError("Aquire must be called with either [package:string, username:string, [password:string, domain:string], callback:function]");
 
-  if(args.Length() == 5 && !args[4]->IsFunction())
-    return NanThrowError("Aquire must be called with either [package:string, username:string, [password:string, domain:string], callback:function]");
+  if(info.Length() == 5 && !info[4]->IsFunction())
+    return Nan::ThrowError("Aquire must be called with either [package:string, username:string, [password:string, domain:string], callback:function]");
 
   Local<Function> callbackHandle;
 
   // Figure out which parameter is the callback
-  if(args.Length() == 5) {
-    callbackHandle = Local<Function>::Cast(args[4]);
-  } else if(args.Length() == 4) {
-    callbackHandle = Local<Function>::Cast(args[3]);
-  } else if(args.Length() == 3) {
-    callbackHandle = Local<Function>::Cast(args[2]);
+  if(info.Length() == 5) {
+    callbackHandle = Local<Function>::Cast(info[4]);
+  } else if(info.Length() == 4) {
+    callbackHandle = Local<Function>::Cast(info[3]);
+  } else if(info.Length() == 3) {
+    callbackHandle = Local<Function>::Cast(info[2]);
   }
 
   // Unpack the package
-  Local<String> package = args[0]->ToString();
+  Local<String> package = info[0]->ToString();
   package_str = (char *)calloc(package->Utf8Length() + 1, sizeof(char));
   package->WriteUtf8(package_str);
 
   // Unpack the user name
-  Local<String> username = args[1]->ToString();
+  Local<String> username = info[1]->ToString();
   username_str = (char *)calloc(username->Utf8Length() + 1, sizeof(char));
   username->WriteUtf8(username_str);
 
   // If we have a password
-  if(args.Length() == 3 || args.Length() == 4 || args.Length() == 5) {
-    Local<String> password = args[2]->ToString();
+  if(info.Length() == 3 || info.Length() == 4 || info.Length() == 5) {
+    Local<String> password = info[2]->ToString();
     password_str = (char *)calloc(password->Utf8Length() + 1, sizeof(char));
     password->WriteUtf8(password_str);    
   }
 
   // If we have a domain
-  if((args.Length() == 4 || args.Length() == 5) && args[3]->IsString()) {
-    Local<String> domain = args[3]->ToString();
+  if((info.Length() == 4 || info.Length() == 5) && info[3]->IsString()) {
+    Local<String> domain = info[3]->ToString();
     domain_str = (char *)calloc(domain->Utf8Length() + 1, sizeof(char));
     domain->WriteUtf8(domain_str);    
   }
@@ -185,7 +185,7 @@ NAN_METHOD(SecurityCredentials::Aquire) {
   call->username_str = username_str;
 
   // Unpack the callback
-  NanCallback *callback = new NanCallback(callbackHandle);
+  Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   // Let's allocate some space
   Worker *worker = new Worker();
@@ -200,26 +200,26 @@ NAN_METHOD(SecurityCredentials::Aquire) {
   uv_queue_work(uv_default_loop(), &worker->request, SecurityCredentials::Process, (uv_after_work_cb)SecurityCredentials::After);
 
   // Return no value as it's callback based
-  NanReturnValue(NanUndefined());
+  info.GetReturnValue().Set(Nan::Undefined());
 }
 
 void SecurityCredentials::Initialize(Handle<Object> target) {
   // Grab the scope of the call from Node
-  NanScope();
+  Nan::HandleScope scope;
 
   // Define a new function template
-  Local<FunctionTemplate> t = NanNew<FunctionTemplate>(New);
+  Local<FunctionTemplate> t = Nan::New<FunctionTemplate>(New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(NanNew<String>("SecurityCredentials"));
+  t->SetClassName(Nan::New<String>("SecurityCredentials").ToLocalChecked());
 
   // Class methods
   NODE_SET_METHOD(t, "aquire", Aquire);
 
   // Set persistent
-  NanAssignPersistent(constructor_template, t);
+  constructor_template.Reset(t);
 
   // Set the symbol
-  target->ForceSet(NanNew<String>("SecurityCredentials"), t->GetFunction());
+  target->ForceSet(Nan::New<String>("SecurityCredentials").ToLocalChecked(), t->GetFunction());
 
   // Attempt to load the security.dll library
   load_library();
@@ -296,51 +296,51 @@ void SecurityCredentials::Process(uv_work_t* work_req) {
 
 void SecurityCredentials::After(uv_work_t* work_req) {
   // Grab the scope of the call from Node
-  NanScope();
+  Nan::HandleScope scope;
 
   // Get the worker reference
   Worker *worker = static_cast<Worker*>(work_req->data);
 
   // If we have an error
   if(worker->error) {
-    Local<Value> err = v8::Exception::Error(NanNew<String>(worker->error_message));
+    Local<Value> err = v8::Exception::Error(Nan::New<String>(worker->error_message).ToLocalChecked());
     Local<Object> obj = err->ToObject();
-    obj->Set(NanNew("code"), NanNew<Int32>(worker->error_code));
-    Local<Value> args[2] = { err, NanNull() };
+    obj->Set(Nan::New<String>("code").ToLocalChecked(), Nan::New<Int32>(worker->error_code));
+    Local<Value> info[2] = { err, Nan::Null() };
     // Execute the error
-    v8::TryCatch try_catch;
+    Nan::TryCatch try_catch;
 
     // Call the callback
-    worker->callback->Call(ARRAY_SIZE(args), args);
+    worker->callback->Call(ARRAY_SIZE(info), info);
 
     // If we have an exception handle it as a fatalexception
     if (try_catch.HasCaught()) {
-      node::FatalException(try_catch);
+      Nan::FatalException(try_catch);
     }
   } else {
     SecurityCredentials *return_value = (SecurityCredentials *)worker->return_value;
     // Create a new instance
-    Local<Object> result = NanNew(constructor_template)->GetFunction()->NewInstance();
+    Local<Object> result = Nan::New(constructor_template)->GetFunction()->NewInstance();
     // Unwrap the credentials
-    SecurityCredentials *security_credentials = ObjectWrap::Unwrap<SecurityCredentials>(result);
+    SecurityCredentials *security_credentials = Nan::ObjectWrap::Unwrap<SecurityCredentials>(result);
     // Set the values
     security_credentials->m_Identity = return_value->m_Identity;
     security_credentials->m_Credentials = return_value->m_Credentials;
     security_credentials->Expiration = return_value->Expiration;
     // Set up the callback with a null first
-    Handle<Value> args[2] = { NanNull(), result};
+    Handle<Value> info[2] = { Nan::Null(), result};
     // Wrap the callback function call in a TryCatch so that we can call
     // node's FatalException afterwards. This makes it possible to catch
     // the exception from JavaScript land using the
     // process.on('uncaughtException') event.
-    v8::TryCatch try_catch;
+    Nan::TryCatch try_catch;
     
     // Call the callback
-    worker->callback->Call(ARRAY_SIZE(args), args);
+    worker->callback->Call(ARRAY_SIZE(info), info);
     
     // If we have an exception handle it as a fatalexception
     if (try_catch.HasCaught()) {
-      node::FatalException(try_catch);
+      Nan::FatalException(try_catch);
     }
   }
 

--- a/lib/win32/wrappers/security_credentials.h
+++ b/lib/win32/wrappers/security_credentials.h
@@ -30,32 +30,32 @@ extern "C" {
 using namespace v8;
 using namespace node;
 
-class SecurityCredentials : public Nan::ObjectWrap {  
-  public:    
+class SecurityCredentials : public Nan::ObjectWrap {
+  public:
     SecurityCredentials();
-    ~SecurityCredentials();    
+    ~SecurityCredentials();
 
     // Pointer to context object
     SEC_WINNT_AUTH_IDENTITY m_Identity;
     // credentials
-    CredHandle m_Credentials;    
+    CredHandle m_Credentials;
     // Expiry time for ticket
     TimeStamp Expiration;
 
     // Has instance check
-    static inline bool HasInstance(Handle<Value> val) {
+    static inline bool HasInstance(Local<Value> val) {
       if (!val->IsObject()) return false;
       Local<Object> obj = val->ToObject();
       return Nan::New(constructor_template)->HasInstance(obj);
     };
 
     // Functions available from V8
-    static void Initialize(Handle<Object> target);    
+    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(Aquire);
 
     // Constructor used for creating new Long objects from C++
     static Nan::Persistent<FunctionTemplate> constructor_template;
-    
+
   private:
     // Create a new instance
     static NAN_METHOD(New);

--- a/lib/win32/wrappers/security_credentials.h
+++ b/lib/win32/wrappers/security_credentials.h
@@ -11,7 +11,7 @@
 #include <windows.h>
 #include <sspi.h>
 #include <tchar.h>
-#include "nan.h"
+#include <nan.h>
 #include "../worker.h"
 #include <uv.h>
 
@@ -30,7 +30,7 @@ extern "C" {
 using namespace v8;
 using namespace node;
 
-class SecurityCredentials : public ObjectWrap {  
+class SecurityCredentials : public Nan::ObjectWrap {  
   public:    
     SecurityCredentials();
     ~SecurityCredentials();    
@@ -46,7 +46,7 @@ class SecurityCredentials : public ObjectWrap {
     static inline bool HasInstance(Handle<Value> val) {
       if (!val->IsObject()) return false;
       Local<Object> obj = val->ToObject();
-      return NanNew(constructor_template)->HasInstance(obj);
+      return Nan::New(constructor_template)->HasInstance(obj);
     };
 
     // Functions available from V8
@@ -54,7 +54,7 @@ class SecurityCredentials : public ObjectWrap {
     static NAN_METHOD(Aquire);
 
     // Constructor used for creating new Long objects from C++
-    static Persistent<FunctionTemplate> constructor_template;
+    static Nan::Persistent<FunctionTemplate> constructor_template;
     
   private:
     // Create a new instance

--- a/lib/worker.h
+++ b/lib/worker.h
@@ -3,7 +3,7 @@
 
 #include <node.h>
 #include <node_object_wrap.h>
-#include <nan.h>    
+#include <nan.h>
 #include <v8.h>
 
 using namespace node;
@@ -32,7 +32,7 @@ class Worker {
     int return_code;
     // Method we are going to fire
     void (*execute)(Worker *worker);
-    Handle<Value> (*mapper)(Worker *worker);
+    Local<Value> (*mapper)(Worker *worker);
 };
 
 #endif  // WORKER_H_

--- a/lib/worker.h
+++ b/lib/worker.h
@@ -17,7 +17,7 @@ class Worker {
     // libuv's request struct.
     uv_work_t request;
     // Callback
-    NanCallback *callback;
+    Nan::Callback *callback;
     // Parameters
     void *parameters;
     // Results

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "devDependencies": {
     "nodeunit": "latest"
   },
-  "scripts": { 
-    "install" : "(node-gyp rebuild 2> builderror.log) || (exit 0)", 
-    "test" : "nodeunit ./test" 
+  "scripts": {
+    "install" : "(node-gyp rebuild) || (exit 0)",
+    "test" : "nodeunit ./test"
   },
   "author": "Christian Amor Kvalheim",
   "license": "Apache 2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "authentication"
   ],
   "dependencies": {
-    "nan": "~1.8"
+    "nan": "~2.0"
   },
   "devDependencies": {
     "nodeunit": "latest"

--- a/test/kerberos_win32_test.js
+++ b/test/kerberos_win32_test.js
@@ -1,10 +1,4 @@
-exports.setUp = function(callback) {
-  callback();
-}
-
-exports.tearDown = function(callback) {
-  callback();
-}
+if (/^win/.test(process.platform)) {
 
 exports['Simple initialize of Kerberos win32 object'] = function(test) {
   var KerberosNative = require('../build/Release/kerberos').Kerberos;
@@ -16,4 +10,6 @@ exports['Simple initialize of Kerberos win32 object'] = function(test) {
   console.dir(kerberos.prepareOutboundPackage("mongodb/kdc.10gen.com"));
   console.log("=========================================== 2")
   test.done();
+}
+
 }


### PR DESCRIPTION
Intended to replace #24 and @christkv's follow-up commits in christkv/bazineta-master.
- The next version of v8 removes `Handle`. Changed to `Local` preemptively.
- `Nan::HandleScope` is implicit after any `NAN_*` macros. Removed.
- Some other nan-ifications/updates to allow it to build with 0.8 and be less likely to break in future versions.
- Added a .travis.yml file to test node 0.8 through 4.0.

The unit tests don't really seem to test anything. This builds everywhere, including on Windows, but I can't comment on whether or not this actually works.

https://travis-ci.org/zbjornson/kerberos/builds/80161475
