### PR TITLE
Corrected license identifier in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test" : "nodeunit ./test"
   },
   "author": "Christian Amor Kvalheim",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "readmeFilename": "README.md",
   "gitHead": "035be2e4619d7f3d7ea5103da1f60a6045ef8d7c"
 }


### PR DESCRIPTION
This teeny-tiny pull request adds a hyphen to the `license` property in `package.json` so that it validates without a warning.

[SPDX](https://spdx.org), which assigns the standard identifiers for common open-source licenses, chose to go with `Apache-2.0`.

Thanks!

K
