### PR TITLE
Implement kerberos username/password checking and other misc. improvements

### DIFF
--- a/lib/kerberos.h
+++ b/lib/kerberos.h
@@ -38,6 +38,7 @@ public:
   static NAN_METHOD(AuthGSSServerInit);
   static NAN_METHOD(AuthGSSServerClean);
   static NAN_METHOD(AuthGSSServerStep);
+  static NAN_METHOD(AuthUserKrb5Password);
 
 private:
   static NAN_METHOD(New);

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -19,6 +19,10 @@ Kerberos.prototype.authGSSClientInit = function(uri, flags, credentialsCache, ca
     credentialsCache = '';
   }
 
+  if (credentialsCache === undefined) {
+      credentialsCache = '';
+  }
+  
   return this._native_kerberos.authGSSClientInit(uri, flags, credentialsCache, callback);
 }
 

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -8,8 +8,18 @@ var Kerberos = function() {
 // callback takes two arguments, an error string if defined and a new context
 // uri should be given as service@host.  Services are not always defined
 // in a straightforward way.  Use 'HTTP' for SPNEGO / Negotiate authentication. 
-Kerberos.prototype.authGSSClientInit = function(uri, flags, callback) {
-  return this._native_kerberos.authGSSClientInit(uri, flags, callback);
+// If credentialsCache is not specified, the default credentials cache from the 
+// environment will be used (ie. KRB5CCNAME).  In the case where multiple 
+// credentials caches may be in use at once (such as for a server doing 
+// delegation), specify the cache name here and it will be used for this 
+// exchange. The credentialsCache is optional.
+Kerberos.prototype.authGSSClientInit = function(uri, flags, credentialsCache, callback) {
+  if (typeof(credentialsCache) == 'function') {
+    callback = credentialsCache;
+    credentialsCache = '';
+  }
+
+  return this._native_kerberos.authGSSClientInit(uri, flags, credentialsCache, callback);
 }
 
 // This will obtain credentials using a credentials cache. To override the default

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -71,7 +71,9 @@ Kerberos.prototype.authGSSClientClean = function(context, callback) {
 //
 // a boolean turns on "constrained_delegation". this enables acquisition of S4U2Proxy 
 // credentials which will be stored in a credentials cache during the authGSSServerStep
-// method. this parameter is optional.
+// method. this parameter is optional.  The credentials will be stored in 
+// a new cache, the location of which will be made available as the "delegatedCredentialsCache"
+// property on the returned context AFTER the authGSSServerStep stage.
 //
 // when "constrained_delegation" is enabled, a username can (optionally) be provided and
 // S4U2Self protocol transition will be initiated. In this case, we will not

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -113,6 +113,17 @@ Kerberos.prototype.authGSSServerStep = function(context, authData, callback) {
   return this._native_kerberos.authGSSServerStep(context, authData, callback);
 };
 
+// authenticate the username and password against the KDC, and verify the KDC using a local
+// service key stored in the keytab.  See above for details on providing the keytab.
+// The service should be the service principal name for a key available in the local keytab,
+// e.g. HTTP/somehost.example.com.  If service is an empty tring, KDC verification will
+// be skipped.  DON'T DO THIS - it's a possible security vulnerability if an attacker
+// can spoof your KDC  (see: https://github.com/qesuto/node-krb5/issues/13)
+// callback receives error and boolean
+Kerberos.prototype.authUserKrb5Password = function(username, password, service, callback) {
+    return this._native_kerberos.authUserKrb5Password(username, password, service, callback);
+};
+
 Kerberos.prototype.acquireAlternateCredentials = function(user_name, password, domain) {
   return this._native_kerberos.acquireAlternateCredentials(user_name, password, domain); 
 }

--- a/lib/kerberosgss.c
+++ b/lib/kerberosgss.c
@@ -922,12 +922,11 @@ static gss_client_response *other_error(const char *fmt, ...)
     va_start(ap, fmt);
 
     va_copy(aps, ap);
-    needed = snprintf(NULL, 0, fmt, aps);
+    needed = vsnprintf(NULL, 0, fmt, aps) + 1;
     va_end(aps);
 
     msg = malloc(needed);
     if (!msg) die1("Memory allocation failed");
-
     vsnprintf(msg, needed, fmt, ap);
     va_end(ap);
 

--- a/lib/kerberosgss.h
+++ b/lib/kerberosgss.h
@@ -70,4 +70,9 @@ gss_client_response *authenticate_gss_server_init(const char* service, bool cons
 gss_client_response *authenticate_gss_server_clean(gss_server_state *state);
 gss_client_response *authenticate_gss_server_step(gss_server_state *state, const char *challenge);
 
+gss_client_response *authenticate_user_krb5_password(const char *username,
+							 const char *password,
+							 const char *service);
+
+
 #endif

--- a/lib/kerberosgss.h
+++ b/lib/kerberosgss.h
@@ -43,6 +43,7 @@ typedef struct {
   long int         gss_flags;
   char*            username;
   char*            response;
+  char*            credentials_cache;
 } gss_client_state;
 
 typedef struct {
@@ -60,7 +61,7 @@ typedef struct {
 
 // char* server_principal_details(const char* service, const char* hostname);
 
-gss_client_response *authenticate_gss_client_init(const char* service, long int gss_flags, gss_client_state* state);
+gss_client_response *authenticate_gss_client_init(const char* service, long int gss_flags, const char* credentials_cache, gss_client_state* state);
 gss_client_response *authenticate_gss_client_clean(gss_client_state *state);
 gss_client_response *authenticate_gss_client_step(gss_client_state *state, const char *challenge);
 gss_client_response *authenticate_gss_client_unwrap(gss_client_state* state, const char* challenge);

--- a/test/kerberos_tests.js
+++ b/test/kerberos_tests.js
@@ -32,3 +32,15 @@ exports['Simple initialize of Kerberos object'] = function(test) {
     });
   });
 }
+
+// for this test, please set the environment variables shown below.
+exports['Simple username password test'] = function(test) {
+    var Kerberos = require('../lib/kerberos.js').Kerberos;
+    var kerberos = new Kerberos();
+    kerberos.authUserKrb5Password(process.env.KRB5_PW_TEST_USERNAME, process.env.KRB5_PW_TEST_PASSWORD, process.env.KRB5_PW_TEST_SERVICE, function(err, ok) {
+        console.log("err:",err);
+        console.log("ok:", ok);
+        test.equal(ok, true);
+        test.done();
+    });
+};

--- a/test/kerberos_tests.js
+++ b/test/kerberos_tests.js
@@ -44,3 +44,64 @@ exports['Simple username password test'] = function(test) {
         test.done();
     });
 };
+
+//for this test, please set the environment variables shown below.
+exports['Negotiate HTTP Client Test'] = function(test) {
+    ///// REQUIRED ENVIRONMENT VARIABLES /////
+    // give the host and path to a Negotiate protected resource on your network
+    var httpHostname = process.env.NEGOTIATE_TEST_HOSTNAME;
+    var httpPath = process.env.NEGOTIATE_TEST_PATH;
+    ////  OPTIONAL ENVIRONMENT VARIABLES
+    // don't use the cache in $KRB5CCNAME, use the one in $NEGOTIATE_TEST_KRB5CCNAME instead
+    var krb5CcName = process.env.NEGOTIATE_TEST_KRB5CCNAME || ''; 
+    /////
+
+    var serviceName = "HTTP@"+httpHostname;
+
+    var Kerberos = require('../lib/kerberos.js').Kerberos;
+    var kerberos = new Kerberos();
+    var http = require('http');
+
+    kerberos.authGSSClientInit(serviceName, 0, krb5CcName, function(err, ctx) {
+       console.log("authGSSClientInit error: ",err);
+       test.equal(null, err);
+
+       kerberos.authGSSClientStep(ctx, "", function(err) {
+           console.log("authGSSClientStep error: ",err);
+           test.equal(null, err);
+
+           var cleanupCtx = function() {
+               kerberos.authGSSClientClean(ctx, function(err) {
+                   console.log("authGSSClientClean error: ",err);
+                   test.equal(null, err);
+                   test.done(); 
+               });
+           };
+
+           var negotiateHeader = "Negotiate " + ctx.response;
+
+           var req = http.get({
+               hostname: httpHostname,
+               path: httpPath,
+               headers: {
+                   authorization: negotiateHeader
+               }
+           }, function(res) {
+               console.log("http res: ", res.statusCode);
+               test.ok(res.statusCode >= 200 && res.statusCode <= 299, "http response status indicates success");
+
+               res.on('data', function(data) {console.log('data:' +data)});
+               res.on('end', function() {
+                   cleanupCtx();
+               });
+
+           });
+
+           req.on('error', function(err) {
+              test.ok(false, 'http.get request failed: '+err.message); 
+              cleanupCtx();
+           });
+
+       }) ;
+    });
+};

--- a/test/kerberos_tests.js
+++ b/test/kerberos_tests.js
@@ -37,6 +37,12 @@ exports['Simple initialize of Kerberos object'] = function(test) {
 exports['Simple username password test'] = function(test) {
     var Kerberos = require('../lib/kerberos.js').Kerberos;
     var kerberos = new Kerberos();
+
+    if (!process.env.KRB5_PW_TEST_USERNAME) {
+        test.done();
+        return;
+    }
+
     kerberos.authUserKrb5Password(process.env.KRB5_PW_TEST_USERNAME, process.env.KRB5_PW_TEST_PASSWORD, process.env.KRB5_PW_TEST_SERVICE, function(err, ok) {
         console.log("err:",err);
         console.log("ok:", ok);
@@ -55,6 +61,11 @@ exports['Negotiate HTTP Client Test'] = function(test) {
     // don't use the cache in $KRB5CCNAME, use the one in $NEGOTIATE_TEST_KRB5CCNAME instead
     var krb5CcName = process.env.NEGOTIATE_TEST_KRB5CCNAME || ''; 
     /////
+
+    if (!httpHostname) {
+        test.done();
+        return;
+    }
 
     var serviceName = "HTTP@"+httpHostname;
 


### PR DESCRIPTION
This pull request implements a new method to check a username and password against a kerberos installation.  This makes the module feature complete for implementing authentication in a kerberos environment.

It also adds the ability to specify via the API the credentials cache to use when creating the security context.  Up until now this was completely handled by the implementation, most likely by consulting KRB5CCNAME environment variable.  In the situation  where delegated credentials are being used for potentially multiple users "simultaneously" it is necessary to be able to explicitly control the cache used.  This should be 100% backwards compatible (at the JS API level).
