### PR TITLE
API to use mechanism specific OID

### DIFF
--- a/lib/kerberos.cc
+++ b/lib/kerberos.cc
@@ -153,8 +153,8 @@ NAN_METHOD(Kerberos::AuthGSSClientInit) {
 
   // Ensure valid call
   if(info.Length() != 5) return Nan::ThrowError(usage);
-  if(!info[0]->IsString() || !info[1]->IsInt32() || !info[2]->IsString() || !info[3]->IsFunction()
-    || !(info[4]->IsUndefined() || info[4]->IsInt32()))
+  if(!info[0]->IsString() || !info[1]->IsInt32() || !info[2]->IsString() || !info[4]->IsFunction()
+    || !(info[3]->IsUndefined() || info[3]->IsInt32()))
       return Nan::ThrowError(usage);
 
   Local<String> service = info[0]->ToString();
@@ -179,13 +179,13 @@ NAN_METHOD(Kerberos::AuthGSSClientInit) {
   call->flags = Nan::To<uint32_t>(info[1]).FromJust();
   call->uri = service_str;
   call->credentials_cache = credentials_cache_str;
-  if(info[4]->IsInt32())
+  if(info[3]->IsInt32())
     call->oid = GSS_C_NO_OID;
   else
     call->oid = gss_krb5_nt_service_name;
   
   // Unpack the callback
-  Local<Function> callbackHandle = Local<Function>::Cast(info[3]);
+  Local<Function> callbackHandle = Local<Function>::Cast(info[4]);
   Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   // Let's allocate some space

--- a/lib/kerberos.cc
+++ b/lib/kerberos.cc
@@ -23,6 +23,7 @@ typedef struct AuthGSSClientCall {
   uint32_t  flags;
   char *uri;
   char *credentials_cache;
+  gss_OID oid;
 } AuthGSSClientCall;
 
 typedef struct AuthGSSClientStepCall {
@@ -119,7 +120,7 @@ static void _authGSSClientInit(Worker *worker) {
   // Unpack the parameter data struct
   AuthGSSClientCall *call = (AuthGSSClientCall *)worker->parameters;
   // Start the kerberos client
-  response = authenticate_gss_client_init(call->uri, call->flags, call->credentials_cache, state);
+  response = authenticate_gss_client_init(call->uri, call->flags, call->credentials_cache, state, call->oid);
 
   // Release the parameter struct memory
   free(call->uri);
@@ -151,8 +152,9 @@ NAN_METHOD(Kerberos::AuthGSSClientInit) {
   const char *usage = "Requires a service string uri, integer flags, string credentialsCache and a callback function";
 
   // Ensure valid call
-  if(info.Length() != 4) return Nan::ThrowError(usage);
-  if(!info[0]->IsString() || !info[1]->IsInt32() || !info[2]->IsString() || !info[3]->IsFunction())
+  if(info.Length() != 5) return Nan::ThrowError(usage);
+  if(!info[0]->IsString() || !info[1]->IsInt32() || !info[2]->IsString() || !info[3]->IsFunction()
+    || !(info[4]->IsUndefined() || info[4]->IsInt32()))
       return Nan::ThrowError(usage);
 
   Local<String> service = info[0]->ToString();
@@ -177,7 +179,11 @@ NAN_METHOD(Kerberos::AuthGSSClientInit) {
   call->flags = Nan::To<uint32_t>(info[1]).FromJust();
   call->uri = service_str;
   call->credentials_cache = credentials_cache_str;
-
+  if(info[4]->IsInt32())
+    call->oid = GSS_C_NO_OID;
+  else
+    call->oid = gss_krb5_nt_service_name;
+  
   // Unpack the callback
   Local<Function> callbackHandle = Local<Function>::Cast(info[3]);
   Nan::Callback *callback = new Nan::Callback(callbackHandle);

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -14,6 +14,15 @@ var Kerberos = function() {
 // delegation), specify the cache name here and it will be used for this 
 // exchange. The credentialsCache is optional.
 Kerberos.prototype.authGSSClientInit = function(uri, flags, credentialsCache, callback) {
+  return authClientInit.call(this, uri, flags, credentialsCache, callback);
+}
+
+// uses mechanism specific OID 
+Kerberos.prototype.authGSSClientInitDefault = function(uri, flags, credentialsCache, callback) {
+  return authClientInit.call(this, uri, flags, credentialsCache, callback, Kerberos.GSS_C_NO_OID);
+}
+
+let authClientInit = function(uri, flags, credentialsCache, callback, oid = undefined){
   if (typeof(credentialsCache) == 'function') {
     callback = credentialsCache;
     credentialsCache = '';
@@ -23,7 +32,7 @@ Kerberos.prototype.authGSSClientInit = function(uri, flags, credentialsCache, ca
       credentialsCache = '';
   }
   
-  return this._native_kerberos.authGSSClientInit(uri, flags, credentialsCache, callback);
+  return this._native_kerberos.authGSSClientInit(uri, flags, credentialsCache, callback, oid );
 }
 
 // This will obtain credentials using a credentials cache. To override the default
@@ -166,6 +175,7 @@ Kerberos.AUTH_GSS_CONTINUE     = 0;
 Kerberos.AUTH_GSS_COMPLETE     = 1;
      
 // Some useful gss flags 
+Kerberos.GSS_C_NO_OID          = 0;
 Kerberos.GSS_C_DELEG_FLAG      = 1;
 Kerberos.GSS_C_MUTUAL_FLAG     = 2;
 Kerberos.GSS_C_REPLAY_FLAG     = 4;

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -22,7 +22,7 @@ Kerberos.prototype.authGSSClientInitDefault = function(uri, flags, credentialsCa
   return authClientInit.call(this, uri, flags, credentialsCache, callback, Kerberos.GSS_C_NO_OID);
 }
 
-var authClientInit = function(uri, flags, credentialsCache, callback, oid = undefined){
+var authClientInit = function(uri, flags, credentialsCache, callback, oid){
   if (typeof(credentialsCache) == 'function') {
     callback = credentialsCache;
     credentialsCache = '';

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -22,7 +22,7 @@ Kerberos.prototype.authGSSClientInitDefault = function(uri, flags, credentialsCa
   return authClientInit.call(this, uri, flags, credentialsCache, callback, Kerberos.GSS_C_NO_OID);
 }
 
-let authClientInit = function(uri, flags, credentialsCache, callback, oid = undefined){
+var authClientInit = function(uri, flags, credentialsCache, callback, oid = undefined){
   if (typeof(credentialsCache) == 'function') {
     callback = credentialsCache;
     credentialsCache = '';

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -19,20 +19,27 @@ Kerberos.prototype.authGSSClientInit = function(uri, flags, credentialsCache, ca
 
 // uses mechanism specific OID 
 Kerberos.prototype.authGSSClientInitDefault = function(uri, flags, credentialsCache, callback) {
-  return authClientInit.call(this, uri, flags, credentialsCache, callback, Kerberos.GSS_C_NO_OID);
+  return authClientInit.call(this, uri, flags, credentialsCache, Kerberos.GSS_C_NO_OID, callback);
 }
 
-var authClientInit = function(uri, flags, credentialsCache, callback, oid){
+var authClientInit = function(uri, flags, credentialsCache, oid, callback){
+// var authClientInit = function(uri, flags, credentialsCache, callback, oid){
   if (typeof(credentialsCache) == 'function') {
     callback = credentialsCache;
     credentialsCache = '';
+    oid = undefined;
   }
 
+  if (typeof(oid) == 'function') {
+    callback = oid;
+    oid = undefined;
+  }
+  
   if (credentialsCache === undefined) {
       credentialsCache = '';
   }
   
-  return this._native_kerberos.authGSSClientInit(uri, flags, credentialsCache, callback, oid );
+  return this._native_kerberos.authGSSClientInit(uri, flags, credentialsCache, oid, callback);
 }
 
 // This will obtain credentials using a credentials cache. To override the default

--- a/lib/kerberosgss.c
+++ b/lib/kerberosgss.c
@@ -150,7 +150,7 @@ end:
     return result;
 }
 */
-gss_client_response *authenticate_gss_client_init(const char* service, long int gss_flags, const char* credentials_cache, gss_client_state* state) {
+gss_client_response *authenticate_gss_client_init(const char* service, long int gss_flags, const char* credentials_cache, gss_client_state* state, gss_OID oid) {
   OM_uint32 maj_stat;
   OM_uint32 min_stat;
   gss_buffer_desc name_token = GSS_C_EMPTY_BUFFER;
@@ -168,7 +168,7 @@ gss_client_response *authenticate_gss_client_init(const char* service, long int 
   name_token.length = strlen(service);
   name_token.value = (char *)service;
 
-  maj_stat = gss_import_name(&min_stat, &name_token, gss_krb5_nt_service_name, &state->server_name);
+  maj_stat = gss_import_name(&min_stat, &name_token, oid , &state->server_name);
 
   if (GSS_ERROR(maj_stat)) {
     response = gss_error(__func__, "gss_import_name", maj_stat, min_stat);

--- a/lib/kerberosgss.h
+++ b/lib/kerberosgss.h
@@ -61,7 +61,7 @@ typedef struct {
 
 // char* server_principal_details(const char* service, const char* hostname);
 
-gss_client_response *authenticate_gss_client_init(const char* service, long int gss_flags, const char* credentials_cache, gss_client_state* state);
+gss_client_response *authenticate_gss_client_init(const char *service, long int gss_flags, const char *credentials_cache, gss_client_state *state, gss_OID oid);
 gss_client_response *authenticate_gss_client_clean(gss_client_state *state);
 gss_client_response *authenticate_gss_client_step(gss_client_state *state, const char *challenge);
 gss_client_response *authenticate_gss_client_unwrap(gss_client_state* state, const char* challenge);


### PR DESCRIPTION
Adding API `Kerberos#authGSSClientInitDefault` that uses GSS_C_NO_OID to generate security context. This will extend the usage of package to HTTP and SPN based services.

Fixes #13