### PR TITLE
NODE-1525: Introduce KerberosWorker

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -5,6 +5,10 @@
 #include "kerberos_gss.h"
 
 // Provide a default custom delter for the `gss_result` type
+inline void ResultDeleter(gss_result* result) {
+  free(result);
+}
+
 struct FreeDeleter {
     void operator()(void* result) {
         free(result);

--- a/src/common.h
+++ b/src/common.h
@@ -9,12 +9,6 @@ inline void ResultDeleter(gss_result* result) {
   free(result);
 }
 
-struct FreeDeleter {
-    void operator()(void* result) {
-        free(result);
-    }
-};
-
 // Useful methods for optional value handling
 NAN_INLINE std::string StringOptionValue(v8::Local<v8::Object> options, const char* _key) {
     Nan::HandleScope scope;

--- a/src/kerberos_client.cc
+++ b/src/kerberos_client.cc
@@ -36,7 +36,7 @@ v8::Local<v8::Object> KerberosClient::NewInstance(gss_client_state* state) {
     return scope.Escape(object);
 }
 
-KerberosClient::KerberosClient(gss_client_state* state) : _state(state), _contextComplete(false) {}
+KerberosClient::KerberosClient(gss_client_state* state) : _state(state) {}
 
 KerberosClient::~KerberosClient() {
     if (_state != NULL) {
@@ -70,7 +70,7 @@ NAN_GETTER(KerberosClient::ResponseConfGetter) {
 
 NAN_GETTER(KerberosClient::ContextCompleteGetter) {
     KerberosClient* client = Nan::ObjectWrap::Unwrap<KerberosClient>(info.This());
-    info.GetReturnValue().Set(Nan::New(client->_contextComplete));
+    info.GetReturnValue().Set(Nan::New(client->_state->context_complete));
 }
 
 NAN_METHOD(KerberosClient::Step) {

--- a/src/kerberos_client.cc
+++ b/src/kerberos_client.cc
@@ -1,6 +1,7 @@
 #include <memory>
 
 #include "kerberos_client.h"
+#include "kerberos_worker.h"
 
 Nan::Persistent<v8::Function> KerberosClient::constructor;
 NAN_MODULE_INIT(KerberosClient::Init) {
@@ -72,114 +73,80 @@ NAN_GETTER(KerberosClient::ContextCompleteGetter) {
     info.GetReturnValue().Set(Nan::New(client->_contextComplete));
 }
 
-class ClientStepWorker : public Nan::AsyncWorker {
-   public:
-    ClientStepWorker(KerberosClient* client, std::string challenge, Nan::Callback* callback)
-        : AsyncWorker(callback, "kerberos:ClientStepWorker"),
-          _client(client),
-          _challenge(challenge) {}
-
-    virtual void Execute() {
-        std::unique_ptr<gss_result, FreeDeleter> result(
-            authenticate_gss_client_step(_client->state(), _challenge.c_str(), NULL));
-        if (result->code == AUTH_GSS_ERROR) {
-            SetErrorMessage(result->message);
-            return;
-        }
-
-        if (result->code == AUTH_GSS_COMPLETE) {
-            _client->_contextComplete = true;
-        }
-    }
-
-   private:
-    virtual void HandleOKCallback() {
-        Nan::HandleScope scope;
-        v8::Local<v8::Value> response = Nan::Null();
-        if (_client->_state->response != NULL) {
-            response = Nan::New(_client->_state->response).ToLocalChecked();
-        }
-
-        v8::Local<v8::Value> argv[] = {Nan::Null(), response};
-        callback->Call(2, argv, async_resource);
-    }
-
-    KerberosClient* _client;
-    std::string _challenge;
-};
-
 NAN_METHOD(KerberosClient::Step) {
     KerberosClient* client = Nan::ObjectWrap::Unwrap<KerberosClient>(info.This());
     std::string challenge(*Nan::Utf8String(info[0]));
     Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
 
-    AsyncQueueWorker(new ClientStepWorker(client, challenge, callback));
+    KerberosWorker::Run(callback, "kerberos:ClientStep", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
+        std::shared_ptr<gss_result> result(
+            authenticate_gss_client_step(client->state(), challenge.c_str(), NULL), ResultDeleter);
+
+        return onFinished([=](KerberosWorker* worker) {
+            Nan::HandleScope scope;
+            if (result->code == AUTH_GSS_ERROR) {
+                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                worker->Call(2, argv);
+                return;
+            }
+
+            v8::Local<v8::Value> response = Nan::Null();
+            if (client->state()->response != NULL) {
+                response = Nan::New(client->state()->response).ToLocalChecked();
+            }
+
+            v8::Local<v8::Value> argv[] = {Nan::Null(), response};
+            worker->Call(2, argv);
+        });
+    });
 }
-
-class ClientUnwrapWorker : public Nan::AsyncWorker {
-   public:
-    ClientUnwrapWorker(KerberosClient* client, std::string challenge, Nan::Callback* callback)
-        : AsyncWorker(callback, "kerberos:ClientUnwrapWorker"),
-          _client(client),
-          _challenge(challenge) {}
-
-    virtual void Execute() {
-        std::unique_ptr<gss_result, FreeDeleter> result(
-            authenticate_gss_client_unwrap(_client->state(), _challenge.c_str()));
-        if (result->code == AUTH_GSS_ERROR) {
-            SetErrorMessage(result->message);
-            return;
-        }
-    }
-
-   private:
-    KerberosClient* _client;
-    std::string _challenge;
-};
 
 NAN_METHOD(KerberosClient::UnwrapData) {
     KerberosClient* client = Nan::ObjectWrap::Unwrap<KerberosClient>(info.This());
     std::string challenge(*Nan::Utf8String(info[0]));
     Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
 
-    AsyncQueueWorker(new ClientUnwrapWorker(client, challenge, callback));
+    KerberosWorker::Run(callback, "kerberos:ClientUnwrap", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
+        std::shared_ptr<gss_result> result(
+            authenticate_gss_client_unwrap(client->state(), challenge.c_str()), ResultDeleter);
+
+        return onFinished([=](KerberosWorker* worker) {
+            Nan::HandleScope scope;
+            if (result->code == AUTH_GSS_ERROR) {
+                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                worker->Call(2, argv);
+                return;
+            }
+
+            v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::Null()};
+            worker->Call(2, argv);
+        });
+    });
 }
-
-class ClientWrapWorker : public Nan::AsyncWorker {
-   public:
-    ClientWrapWorker(KerberosClient* client,
-                     std::string challenge,
-                     std::string user,
-                     int protect,
-                     Nan::Callback* callback)
-        : AsyncWorker(callback, "kerberos:ClientWrapWorker"),
-          _client(client),
-          _challenge(challenge),
-          _user(user),
-          _protect(protect) {}
-
-    virtual void Execute() {
-        std::unique_ptr<gss_result, FreeDeleter> result(authenticate_gss_client_wrap(
-            _client->state(), _challenge.c_str(), _user.c_str(), _protect));
-        if (result->code == AUTH_GSS_ERROR) {
-            SetErrorMessage(result->message);
-            return;
-        }
-    }
-
-   private:
-    KerberosClient* _client;
-    std::string _challenge;
-    std::string _user;
-    int _protect;
-};
 
 NAN_METHOD(KerberosClient::WrapData) {
     KerberosClient* client = Nan::ObjectWrap::Unwrap<KerberosClient>(info.This());
     std::string challenge(*Nan::Utf8String(info[0]));
     v8::Local<v8::Object> options = Nan::To<v8::Object>(info[1]).ToLocalChecked();
     Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[2]).ToLocalChecked());
-
     std::string user = StringOptionValue(options, "user");
-    AsyncQueueWorker(new ClientWrapWorker(client, challenge, user, 0, callback));
+
+    int protect = 0; // NOTE: this should be an option
+
+    KerberosWorker::Run(callback, "kerberos:ClientWrap", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
+        std::shared_ptr<gss_result> result(authenticate_gss_client_wrap(
+            client->state(), challenge.c_str(), user.c_str(), protect), ResultDeleter);
+
+        return onFinished([=](KerberosWorker* worker) {
+            Nan::HandleScope scope;
+            if (result->code == AUTH_GSS_ERROR) {
+                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                worker->Call(2, argv);
+                return;
+            }
+
+            v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::Null()};
+            worker->Call(2, argv);
+        });
+    });
 }

--- a/src/kerberos_client.h
+++ b/src/kerberos_client.h
@@ -23,12 +23,10 @@ class KerberosClient : public Nan::ObjectWrap {
     static NAN_METHOD(WrapData);
 
    private:
-    friend class ClientStepWorker;
     explicit KerberosClient(gss_client_state* client_state);
     ~KerberosClient();
 
     gss_client_state* _state;
-    bool _contextComplete;
 };
 
 #endif

--- a/src/kerberos_gss.cc
+++ b/src/kerberos_gss.cc
@@ -38,6 +38,8 @@ gss_client_state* gss_client_state_new() {
     state->username = NULL;
     state->response = NULL;
     state->responseConf = 0;
+    state->context_complete = false;
+
     return state;
 }
 
@@ -46,6 +48,8 @@ gss_server_state* gss_server_state_new() {
     state->username = NULL;
     state->response = NULL;
     state->targetname = NULL;
+    state->context_complete = false;
+
     return state;
 }
 
@@ -277,6 +281,8 @@ gss_result* authenticate_gss_client_step(gss_client_state* state,
 
     // Try to get the user name if we have completed all GSS operations
     if (temp_ret == AUTH_GSS_COMPLETE) {
+        state->context_complete = true;
+
         gss_name_t gssuser = GSS_C_NO_NAME;
         maj_stat = gss_inquire_context(
             &min_stat, state->context, &gssuser, NULL, NULL, NULL, NULL, NULL, NULL);
@@ -615,6 +621,7 @@ gss_result* authenticate_gss_server_step(gss_server_state* state, const char* ch
     }
 
     ret = gss_success_result(AUTH_GSS_COMPLETE);
+    state->context_complete = true;
 end:
     if (target_name != GSS_C_NO_NAME)
         gss_release_name(&min_stat, &target_name);

--- a/src/kerberos_gss.h
+++ b/src/kerberos_gss.h
@@ -45,6 +45,7 @@ typedef struct {
     char* username;
     char* response;
     int responseConf;
+    bool context_complete;
 } gss_client_state;
 
 typedef struct {
@@ -56,6 +57,7 @@ typedef struct {
     char* username;
     char* targetname;
     char* response;
+    bool context_complete;
 } gss_server_state;
 
 gss_client_state* gss_client_state_new();

--- a/src/kerberos_server.cc
+++ b/src/kerberos_server.cc
@@ -34,7 +34,7 @@ v8::Local<v8::Object> KerberosServer::NewInstance(gss_server_state* state) {
     return scope.Escape(object);
 }
 
-KerberosServer::KerberosServer(gss_server_state* state) : _state(state), _contextComplete(false) {}
+KerberosServer::KerberosServer(gss_server_state* state) : _state(state) {}
 
 KerberosServer::~KerberosServer() {
     if (_state != NULL) {
@@ -70,7 +70,7 @@ NAN_GETTER(KerberosServer::TargetNameGetter) {
 
 NAN_GETTER(KerberosServer::ContextCompleteGetter) {
     KerberosServer* server = Nan::ObjectWrap::Unwrap<KerberosServer>(info.This());
-    info.GetReturnValue().Set(Nan::New(server->_contextComplete));
+    info.GetReturnValue().Set(Nan::New(server->_state->context_complete));
 }
 
 NAN_METHOD(KerberosServer::Step) {

--- a/src/kerberos_server.h
+++ b/src/kerberos_server.h
@@ -21,12 +21,10 @@ class KerberosServer : public Nan::ObjectWrap {
     static NAN_METHOD(Step);
 
    private:
-    friend class ServerStepWorker;
     explicit KerberosServer(gss_server_state* server_state);
     ~KerberosServer();
 
     gss_server_state* _state;
-    bool _contextComplete;
 };
 
 #endif

--- a/src/kerberos_worker.h
+++ b/src/kerberos_worker.h
@@ -1,0 +1,48 @@
+#ifndef ASYNC_WORKER_H
+#define ASYNC_WORKER_H
+
+#include <functional>
+#include <nan.h>
+
+class KerberosWorker : public Nan::AsyncWorker {
+ public:
+    typedef std::function<void(KerberosWorker*)>  OnFinishedHandler;
+    typedef std::function<void(OnFinishedHandler)> SetOnFinishedHandler;
+    typedef std::function<void(SetOnFinishedHandler)> ExecuteHandler;
+
+    explicit KerberosWorker(Nan::Callback *callback, const char* resource_name, ExecuteHandler handler)
+        : Nan::AsyncWorker(callback, resource_name), execute_handler(handler) {}
+
+    template <class... T>
+    void Call(T... t) {
+      callback->Call(t..., async_resource);
+    }
+
+    virtual void Execute() {
+        execute_handler([=] (OnFinishedHandler handler) {
+            on_finished_handler = handler;
+        });
+    }
+
+    static void Run(Nan::Callback *callback, const char* resource_name, ExecuteHandler handler) {
+        Nan::TryCatch tryCatch;
+        if (tryCatch.HasCaught()) {
+            tryCatch.ReThrow();
+            return; // don't proceed in case there were any previous errors
+        }
+
+        auto worker = new KerberosWorker(callback, resource_name, handler);
+        Nan::AsyncQueueWorker(worker);
+    }
+
+ protected:
+    void HandleOKCallback() {
+        on_finished_handler(this);
+    }
+
+ private:
+    ExecuteHandler execute_handler;
+    OnFinishedHandler on_finished_handler;
+};
+
+#endif // ASYNC_WORKER_H


### PR DESCRIPTION
`KerberosWorker` provides a way to execute async operations without needing explicit definition of `nan::AsyncWorker`s in order to improve readability, as well as make it easier to reason about the codebase as we split things up for windows support.