### PR TITLE
Export the package version

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ module.exports = kerberos;
 // Support legacy versions of the mongodb driver which expect this export
 module.exports.Kerberos = kerberos;
 
+module.exports.version = require('./package.json').version;
+
 // Set up the auth processes
 module.exports.processes = {
   MongoAuthProcess: require('./lib/auth_processes/mongodb').MongoAuthProcess

--- a/test/exports_tests.js
+++ b/test/exports_tests.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const api = require('../index');
+
+describe('module', function () {
+  it('should export version', function () {
+    expect(api.version).to.be.a('string');
+    expect(api.version).to.match(/\d+\.\d+/);
+  });
+
+  it('should export flags and ids', function () {
+    [
+      api.GSS_C_DELEG_FLAG,
+      api.GSS_C_MUTUAL_FLAG,
+      api.GSS_C_REPLAY_FLAG,
+      api.GSS_C_SEQUENCE_FLAG,
+      api.GSS_C_CONF_FLAG,
+      api.GSS_C_INTEG_FLAG,
+      api.GSS_C_ANON_FLAG,
+      api.GSS_C_PROT_READY_FLAG,
+      api.GSS_C_TRANS_FLAG,
+      api.GSS_C_NO_OID,
+      api.GSS_MECH_OID_KRB5,
+      api.GSS_MECH_OID_SPNEGO
+    ].forEach(flag => expect(flag).to.be.a('number'));
+  });
+
+  it('should export functions', function () {
+    expect(api.initializeClient).to.be.a('function');
+    expect(api.initializeServer).to.be.a('function');
+    expect(api.principalDetails).to.be.a('function');
+    expect(api.checkPassword).to.be.a('function');
+  });
+
+  it('should export Kerberos', () => {
+    expect(api.Kerberos).to.be.an('object');
+  });
+});


### PR DESCRIPTION
As kerberos can be used as an optional dependency, we expose the
version at api level to allow third party libraries to consume the
version number easily.

It includes a test that verifies what's being exported.

BTW, kudos for the new API in v1.0!