### PR TITLE
fix(define-operation): ensure optional parameters are considered

### DIFF
--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -3,6 +3,7 @@
 const kerberos = require('bindings')('kerberos');
 const KerberosClient = kerberos.KerberosClient;
 const KerberosServer = kerberos.KerberosServer;
+const defineOperation = require('./util').defineOperation;
 
 // GSS Flags
 const GSS_C_DELEG_FLAG = 1;
@@ -19,67 +20,6 @@ const GSS_C_TRANS_FLAG = 256;
 const GSS_C_NO_OID = 0;
 const GSS_MECH_OID_KRB5 = 9;
 const GSS_MECH_OID_SPNEGO = 6;
-
-function validateParameter(parameter, spec) {
-  if (parameter == null) {
-    throw new TypeError(`Required parameter \`${spec.name}\` missing`);
-  }
-
-  if (spec.type && typeof parameter !== spec.type) {
-    throw new TypeError(
-      `Invalid type for parameter \`${spec.name}\`, expected \`${
-        spec.type
-      }\` but found \`${typeof parameter}\``
-    );
-  }
-}
-
-/**
- * Monkey-patches an existing method to support parameter validation, as well
- * as adding support for returning Promises if callbacks are not provided.
- *
- * @private
- * @param {function} fn the function to override
- * @param {Array<Object>} paramDefs the definitions of each parameter to the function
- */
-function defineOperation(fn, paramDefs) {
-  return function() {
-    const args = Array.prototype.slice.call(arguments);
-    const params = [];
-    for (let i = 0; i < paramDefs.length; ++i) {
-      const def = paramDefs[i];
-      let arg = args[i];
-
-      if (def.default && arg == null) arg = def.default;
-      if (def.type === 'object' && def.default != null) {
-        arg = Object.assign({}, def.default, arg);
-      }
-
-      // special case to allow `options` to be optional
-      if (def.name === 'options' && (typeof arg === 'function' || arg == null)) {
-        arg = {};
-      }
-
-      validateParameter(arg, paramDefs[i]);
-      params.push(arg);
-    }
-
-    const callback = arguments[arguments.length - 1];
-    if (typeof callback !== 'function') {
-      return new Promise((resolve, reject) => {
-        params.push((err, response) => {
-          if (err) return reject(err);
-          resolve(response);
-        });
-
-        fn.apply(this, params);
-      });
-    }
-
-    params.push(callback);
-    fn.apply(this, params);
-  };
-}
 
 /**
  * @class KerberosClient
@@ -147,7 +87,7 @@ KerberosClient.prototype.unwrap = defineOperation(KerberosClient.prototype.unwra
  * @kind function
  * @memberof KerberosServer
  * @param {string} challenge A string containing the base64-encoded client data
- * @param {function} callback
+ * @param {function} [callback]
  * @return {Promise} returns Promise if no callback passed
  */
 KerberosServer.prototype.step = defineOperation(KerberosServer.prototype.step, [

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -40,7 +40,8 @@ const GSS_MECH_OID_SPNEGO = 6;
  * @return {Promise} returns Promise if no callback passed
  */
 KerberosClient.prototype.step = defineOperation(KerberosClient.prototype.step, [
-  { name: 'challenge', type: 'string' }
+  { name: 'challenge', type: 'string' },
+  { name: 'callback', type: 'function', required: false }
 ]);
 
 /**
@@ -56,7 +57,8 @@ KerberosClient.prototype.step = defineOperation(KerberosClient.prototype.step, [
  */
 KerberosClient.prototype.wrap = defineOperation(KerberosClient.prototype.wrap, [
   { name: 'challenge', type: 'string' },
-  { name: 'options', type: 'object' }
+  { name: 'options', type: 'object' },
+  { name: 'callback', type: 'function', required: false }
 ]);
 
 /**
@@ -69,7 +71,8 @@ KerberosClient.prototype.wrap = defineOperation(KerberosClient.prototype.wrap, [
  * @return {Promise} returns Promise if no callback passed
  */
 KerberosClient.prototype.unwrap = defineOperation(KerberosClient.prototype.unwrap, [
-  { name: 'challenge', type: 'string' }
+  { name: 'challenge', type: 'string' },
+  { name: 'callback', type: 'function', required: false }
 ]);
 
 /**
@@ -91,7 +94,8 @@ KerberosClient.prototype.unwrap = defineOperation(KerberosClient.prototype.unwra
  * @return {Promise} returns Promise if no callback passed
  */
 KerberosServer.prototype.step = defineOperation(KerberosServer.prototype.step, [
-  { name: 'challenge', type: 'string' }
+  { name: 'challenge', type: 'string' },
+  { name: 'callback', type: 'function', required: false }
 ]);
 
 /**
@@ -123,7 +127,8 @@ const checkPassword = defineOperation(kerberos.checkPassword, [
   { name: 'username', type: 'string' },
   { name: 'password', type: 'string' },
   { name: 'service', type: 'string' },
-  { name: 'defaultRealm', type: 'string' }
+  { name: 'defaultRealm', type: 'string', required: false },
+  { name: 'callback', type: 'function', required: false }
 ]);
 
 /**
@@ -139,7 +144,8 @@ const checkPassword = defineOperation(kerberos.checkPassword, [
  */
 const principalDetails = defineOperation(kerberos.principalDetails, [
   { name: 'service', type: 'string' },
-  { name: 'hostname', type: 'string' }
+  { name: 'hostname', type: 'string' },
+  { name: 'callback', type: 'function', required: false }
 ]);
 
 /**
@@ -156,7 +162,8 @@ const principalDetails = defineOperation(kerberos.principalDetails, [
  */
 const initializeClient = defineOperation(kerberos.initializeClient, [
   { name: 'service', type: 'string' },
-  { name: 'options', type: 'object', default: { mechOID: GSS_C_NO_OID } }
+  { name: 'options', type: 'object', default: { mechOID: GSS_C_NO_OID } },
+  { name: 'callback', type: 'function', required: false }
 ]);
 
 /**
@@ -168,7 +175,8 @@ const initializeClient = defineOperation(kerberos.initializeClient, [
  * @return {Promise} returns Promise if no callback passed
  */
 const initializeServer = defineOperation(kerberos.initializeServer, [
-  { name: 'service', type: 'string' }
+  { name: 'service', type: 'string' },
+  { name: 'callback', type: 'function', required: false }
 ]);
 
 module.exports = {

--- a/lib/util.js
+++ b/lib/util.js
@@ -10,12 +10,16 @@ function validateParameter(parameter, spec) {
   }
 
   if (spec.type && typeof parameter !== spec.type) {
+    if (spec.required === false) return false;
+
     throw new TypeError(
       `Invalid type for parameter \`${spec.name}\`, expected \`${
         spec.type
       }\` but found \`${typeof parameter}\``
     );
   }
+
+  return true;
 }
 
 /**
@@ -30,11 +34,11 @@ function defineOperation(fn, paramDefs) {
   return function() {
     const args = Array.prototype.slice.call(arguments);
     const params = [];
-    for (let i = 0; i < paramDefs.length; ++i) {
+    for (let i = 0, argIdx = 0; i < paramDefs.length; ++i, ++argIdx) {
       const def = paramDefs[i];
-      let arg = args[i];
+      let arg = args[argIdx];
 
-      if (def.default && arg == null) arg = def.default;
+      if (def.hasOwnProperty('default') && arg == null) arg = def.default;
       if (def.type === 'object' && def.default != null) {
         arg = Object.assign({}, def.default, arg);
       }
@@ -44,11 +48,14 @@ function defineOperation(fn, paramDefs) {
         arg = {};
       }
 
-      validateParameter(arg, paramDefs[i]);
-      params.push(arg);
+      if (validateParameter(arg, paramDefs[i])) {
+        params.push(arg);
+      } else {
+        argIdx--;
+      }
     }
 
-    const callback = params.pop();
+    const callback = arguments[arguments.length - 1];
     if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         params.push((err, response) => {
@@ -60,7 +67,6 @@ function defineOperation(fn, paramDefs) {
       });
     }
 
-    params.push(callback);
     fn.apply(this, params);
   };
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,7 @@
 'use strict';
 
-function validateParameter(parameter, spec) {
+function validateParameter(parameter, specs, specIndex) {
+  const spec = specs[specIndex];
   if (parameter == null && spec.required === false) {
     return;
   }
@@ -9,8 +10,13 @@ function validateParameter(parameter, spec) {
     throw new TypeError(`Required parameter \`${spec.name}\` missing`);
   }
 
-  if (spec.type && typeof parameter !== spec.type) {
-    if (spec.required === false) return false;
+  const paramType = typeof parameter;
+  if (spec.type && paramType !== spec.type) {
+    if (spec.required === false) {
+      if (specs.slice(specIndex).some(def => def.type === paramType)) {
+        return false;
+      }
+    }
 
     throw new TypeError(
       `Invalid type for parameter \`${spec.name}\`, expected \`${
@@ -48,7 +54,7 @@ function defineOperation(fn, paramDefs) {
         arg = {};
       }
 
-      if (validateParameter(arg, paramDefs[i])) {
+      if (validateParameter(arg, paramDefs, i)) {
         params.push(arg);
       } else {
         argIdx--;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,68 @@
+'use strict';
+
+function validateParameter(parameter, spec) {
+  if (parameter == null && spec.required === false) {
+    return;
+  }
+
+  if (parameter == null) {
+    throw new TypeError(`Required parameter \`${spec.name}\` missing`);
+  }
+
+  if (spec.type && typeof parameter !== spec.type) {
+    throw new TypeError(
+      `Invalid type for parameter \`${spec.name}\`, expected \`${
+        spec.type
+      }\` but found \`${typeof parameter}\``
+    );
+  }
+}
+
+/**
+ * Monkey-patches an existing method to support parameter validation, as well
+ * as adding support for returning Promises if callbacks are not provided.
+ *
+ * @private
+ * @param {function} fn the function to override
+ * @param {Array<Object>} paramDefs the definitions of each parameter to the function
+ */
+function defineOperation(fn, paramDefs) {
+  return function() {
+    const args = Array.prototype.slice.call(arguments);
+    const params = [];
+    for (let i = 0; i < paramDefs.length; ++i) {
+      const def = paramDefs[i];
+      let arg = args[i];
+
+      if (def.default && arg == null) arg = def.default;
+      if (def.type === 'object' && def.default != null) {
+        arg = Object.assign({}, def.default, arg);
+      }
+
+      // special case to allow `options` to be optional
+      if (def.name === 'options' && (typeof arg === 'function' || arg == null)) {
+        arg = {};
+      }
+
+      validateParameter(arg, paramDefs[i]);
+      params.push(arg);
+    }
+
+    const callback = params.pop();
+    if (typeof callback !== 'function') {
+      return new Promise((resolve, reject) => {
+        params.push((err, response) => {
+          if (err) return reject(err);
+          resolve(response);
+        });
+
+        fn.apply(this, params);
+      });
+    }
+
+    params.push(callback);
+    fn.apply(this, params);
+  };
+}
+
+module.exports = { defineOperation, validateParameter };

--- a/src/kerberos.cc
+++ b/src/kerberos.cc
@@ -132,7 +132,15 @@ NAN_GETTER(KerberosServer::ContextCompleteGetter) {
 NAN_METHOD(TestMethod) {
     std::string string(*Nan::Utf8String(info[0]));
     bool shouldError = info[1]->BooleanValue();
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[2]).ToLocalChecked());
+
+    std::string optionalString;
+    Nan::Callback* callback;
+    if (info[2]->IsFunction()) {
+        callback = new Nan::Callback(Nan::To<v8::Function>(info[2]).ToLocalChecked());
+    } else {
+        optionalString = *Nan::Utf8String(info[2]);
+        callback = new Nan::Callback(Nan::To<v8::Function>(info[3]).ToLocalChecked());
+    }
 
     KerberosWorker::Run(callback, "kerberos:TestMethod", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         return onFinished([=](KerberosWorker* worker) {
@@ -141,7 +149,7 @@ NAN_METHOD(TestMethod) {
                 v8::Local<v8::Value> argv[] = {Nan::Error("an error occurred"), Nan::Null()};
                 worker->Call(2, argv);
             } else {
-                v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::Null()};
+                v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::New(optionalString.c_str()).ToLocalChecked()};
                 worker->Call(2, argv);
             }
         });

--- a/src/kerberos.h
+++ b/src/kerberos.h
@@ -59,4 +59,7 @@ NAN_METHOD(InitializeClient);
 NAN_METHOD(InitializeServer);
 NAN_METHOD(CheckPassword);
 
+// NOTE: explicitly used for unit testing `defineOperation`, not meant to be exported
+NAN_METHOD(TestMethod);
+
 #endif  // KERBEROS_NATIVE_EXTENSION_H

--- a/src/unix/kerberos_unix.cc
+++ b/src/unix/kerberos_unix.cc
@@ -232,8 +232,15 @@ NAN_METHOD(CheckPassword) {
     std::string username(*Nan::Utf8String(info[0]));
     std::string password(*Nan::Utf8String(info[1]));
     std::string service(*Nan::Utf8String(info[2]));
-    std::string defaultRealm(*Nan::Utf8String(info[3]));
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[4]).ToLocalChecked());
+
+    std::string defaultRealm;
+    Nan::Callback* callback;
+    if (info[3]->IsFunction()) {
+        callback = new Nan::Callback(Nan::To<v8::Function>(info[3]).ToLocalChecked());
+    } else {
+        defaultRealm = *Nan::Utf8String(info[3]);
+        callback = new Nan::Callback(Nan::To<v8::Function>(info[4]).ToLocalChecked());
+    }
 
     KerberosWorker::Run(callback, "kerberos:CheckPassword", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         std::shared_ptr<gss_result> result(authenticate_user_krb5pwd(

--- a/src/unix/kerberos_unix.cc
+++ b/src/unix/kerberos_unix.cc
@@ -32,7 +32,7 @@ NAN_METHOD(KerberosClient::Step) {
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
             if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -60,7 +60,7 @@ NAN_METHOD(KerberosClient::UnwrapData) {
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
             if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -87,7 +87,7 @@ NAN_METHOD(KerberosClient::WrapData) {
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
             if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -118,7 +118,7 @@ NAN_METHOD(KerberosServer::Step) {
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
             if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -165,7 +165,7 @@ NAN_METHOD(InitializeClient) {
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
             if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -194,7 +194,7 @@ NAN_METHOD(InitializeServer) {
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
             if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -217,7 +217,7 @@ NAN_METHOD(PrincipalDetails) {
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
             if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -249,7 +249,7 @@ NAN_METHOD(CheckPassword) {
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
             if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
                 worker->Call(2, argv);
             } else {
                 v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::Null()};

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -173,23 +173,13 @@ NAN_METHOD(InitializeClient) {
 }
 
 NAN_METHOD(InitializeServer) {
-    std::string service(*Nan::Utf8String(info[0]));
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
     Nan::ThrowError("`initializeServer` is not implemented yet for windows");
 }
 
 NAN_METHOD(PrincipalDetails) {
-    std::string service(*Nan::Utf8String(info[0]));
-    std::string hostname(*Nan::Utf8String(info[1]));
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[2]).ToLocalChecked());
     Nan::ThrowError("`principalDetails` is not implemented yet for windows");
 }
 
 NAN_METHOD(CheckPassword) {
-    std::string username(*Nan::Utf8String(info[0]));
-    std::string password(*Nan::Utf8String(info[1]));
-    std::string service(*Nan::Utf8String(info[2]));
-    std::string defaultRealm(*Nan::Utf8String(info[3]));
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[4]).ToLocalChecked());
     Nan::ThrowError("`checkPassword` is not implemented yet for windows");
 }

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -48,7 +48,7 @@ NAN_METHOD(KerberosClient::Step) {
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
             if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -76,7 +76,7 @@ NAN_METHOD(KerberosClient::UnwrapData) {
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
             if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -103,7 +103,7 @@ NAN_METHOD(KerberosClient::WrapData) {
             Nan::HandleScope scope;
 
             if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -161,7 +161,7 @@ NAN_METHOD(InitializeClient) {
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
             if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::New(result->message).ToLocalChecked(), Nan::Null()};
+                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }

--- a/test/defineOperation_tests.js
+++ b/test/defineOperation_tests.js
@@ -6,6 +6,7 @@ const expect = require('chai').expect;
 const testMethod = defineOperation(kerberos._testMethod, [
   { name: 'string', type: 'string' },
   { name: 'shouldError', type: 'boolean', default: false },
+  { name: 'optionalString', type: 'string', required: false },
   { name: 'callback', type: 'function', required: false }
 ]);
 
@@ -14,8 +15,30 @@ describe('defineOperation', () => {
     expect(() => testMethod(42)).to.throw(/Invalid type for parameter/);
   });
 
+  it('should support defaults', function(done) {
+    expect(() => testMethod('testing')).to.not.throw();
+    testMethod('testing', true, err => {
+      expect(err).to.exist;
+      done();
+    });
+  });
+
   it('should return a promise if no callback is provided', function() {
     const promise = testMethod('llamas', false);
     expect(promise).to.be.instanceOf(Promise);
+  });
+
+  it('should use a callback if provided', function(done) {
+    testMethod('testing', false, 'optional', (err, result) => {
+      expect(err).to.not.exist;
+      expect(result).to.equal('optional');
+
+      testMethod('testing', true, 'optional', (err, result) => {
+        expect(err).to.exist;
+        expect(result).to.not.exist;
+
+        done();
+      });
+    });
   });
 });

--- a/test/defineOperation_tests.js
+++ b/test/defineOperation_tests.js
@@ -15,6 +15,12 @@ describe('defineOperation', () => {
     expect(() => testMethod(42)).to.throw(/Invalid type for parameter/);
   });
 
+  it('should validate optional parameters, with valid parameters after', function() {
+    expect(() => testMethod('llamas', false, true, () => {})).to.throw(
+      /Invalid type for parameter `optionalString`/
+    );
+  });
+
   it('should support defaults', function(done) {
     expect(() => testMethod('testing')).to.not.throw();
     testMethod('testing', true, err => {

--- a/test/defineOperation_tests.js
+++ b/test/defineOperation_tests.js
@@ -1,0 +1,21 @@
+'use strict';
+const kerberos = require('bindings')('kerberos');
+const defineOperation = require('../lib/util').defineOperation;
+const expect = require('chai').expect;
+
+const testMethod = defineOperation(kerberos._testMethod, [
+  { name: 'string', type: 'string' },
+  { name: 'shouldError', type: 'boolean', default: false },
+  { name: 'callback', type: 'function', required: false }
+]);
+
+describe('defineOperation', () => {
+  it('should validate parameters', function() {
+    expect(() => testMethod(42)).to.throw(/Invalid type for parameter/);
+  });
+
+  it('should return a promise if no callback is provided', function() {
+    const promise = testMethod('llamas', false);
+    expect(promise).to.be.instanceOf(Promise);
+  });
+});

--- a/test/exports_tests.js
+++ b/test/exports_tests.js
@@ -4,13 +4,13 @@ const chai = require('chai');
 const expect = chai.expect;
 const api = require('../index');
 
-describe('module', function () {
-  it('should export version', function () {
+describe('module', function() {
+  it('should export version', function() {
     expect(api.version).to.be.a('string');
     expect(api.version).to.match(/\d+\.\d+/);
   });
 
-  it('should export flags and ids', function () {
+  it('should export flags and ids', function() {
     [
       api.GSS_C_DELEG_FLAG,
       api.GSS_C_MUTUAL_FLAG,
@@ -27,7 +27,7 @@ describe('module', function () {
     ].forEach(flag => expect(flag).to.be.a('number'));
   });
 
-  it('should export functions', function () {
+  it('should export functions', function() {
     expect(api.initializeClient).to.be.a('function');
     expect(api.initializeServer).to.be.a('function');
     expect(api.principalDetails).to.be.a('function');


### PR DESCRIPTION
This turned out to be a little more work than anticipated, but we can now accept optional parameters in our parameter definitions. The `defaultRealm` parameter for `checkPassword` is indeed optional (as documented), and now the validation corroborates that. 