### PR TITLE
Extend windows support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,12 @@ build: off
 skip_tags: true
 
 environment:
+  global:
+    KERBEROS_USERNAME: administrator
+    KERBEROS_PASSWORD: Password01
+    KERBEROS_REALM: example.com
+    KERBEROS_PORT: 80
+
   matrix:
     - nodejs_version: "6"
     - nodejs_version: "8"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,6 @@ build: off
 skip_tags: true
 
 environment:
-  global:
-    KERBEROS_USERNAME: administrator
-    KERBEROS_PASSWORD: Password01
-    KERBEROS_REALM: example.com
-    KERBEROS_PORT: 80
-
   matrix:
     - nodejs_version: "6"
     - nodejs_version: "8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kerberos",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kerberos",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Kerberos library for Node.js",
   "main": "index.js",
   "repository": {

--- a/src/kerberos.cc
+++ b/src/kerberos.cc
@@ -62,7 +62,7 @@ NAN_GETTER(KerberosClient::ResponseConfGetter) {
 
 NAN_GETTER(KerberosClient::ContextCompleteGetter) {
     KerberosClient* client = Nan::ObjectWrap::Unwrap<KerberosClient>(info.This());
-    info.GetReturnValue().Set(Nan::New(client->state()->context_complete));
+    info.GetReturnValue().Set(Nan::New<v8::Boolean>(client->state()->context_complete));
 }
 
 /// KerberosServer
@@ -105,28 +105,28 @@ krb_server_state* KerberosServer::state() const {
 
 NAN_GETTER(KerberosServer::UserNameGetter) {
     KerberosServer* server = Nan::ObjectWrap::Unwrap<KerberosServer>(info.This());
-    (server->_state->username == NULL)
+    (server->state()->username == NULL)
         ? info.GetReturnValue().Set(Nan::Null())
-        : info.GetReturnValue().Set(Nan::New((char*)server->_state->username).ToLocalChecked());
+        : info.GetReturnValue().Set(Nan::New(server->state()->username).ToLocalChecked());
 }
 
 NAN_GETTER(KerberosServer::ResponseGetter) {
     KerberosServer* server = Nan::ObjectWrap::Unwrap<KerberosServer>(info.This());
-    (server->_state->response == NULL)
+    (server->state()->response == NULL)
         ? info.GetReturnValue().Set(Nan::Null())
-        : info.GetReturnValue().Set(Nan::New((char*)server->_state->response).ToLocalChecked());
+        : info.GetReturnValue().Set(Nan::New(server->state()->response).ToLocalChecked());
 }
 
 NAN_GETTER(KerberosServer::TargetNameGetter) {
     KerberosServer* server = Nan::ObjectWrap::Unwrap<KerberosServer>(info.This());
-    (server->_state->targetname == NULL)
+    (server->state()->targetname == NULL)
         ? info.GetReturnValue().Set(Nan::Null())
-        : info.GetReturnValue().Set(Nan::New((char*)server->_state->targetname).ToLocalChecked());
+        : info.GetReturnValue().Set(Nan::New(server->state()->targetname).ToLocalChecked());
 }
 
 NAN_GETTER(KerberosServer::ContextCompleteGetter) {
     KerberosServer* server = Nan::ObjectWrap::Unwrap<KerberosServer>(info.This());
-    info.GetReturnValue().Set(Nan::New(server->_state->context_complete));
+    info.GetReturnValue().Set(Nan::New<v8::Boolean>(server->state()->context_complete));
 }
 
 NAN_METHOD(TestMethod) {

--- a/src/win32/kerberos_sspi.cc
+++ b/src/win32/kerberos_sspi.cc
@@ -342,8 +342,7 @@ auth_sspi_server_step(sspi_server_state* state, const char* challenge)
         InBuffDesc.cBuffers = 1;
         InBuffDesc.pBuffers = &InSecBuff;
     } else {
-        ret = sspi_error_result_with_message("No challenge parameter in request from client");
-        goto end;
+        return sspi_error_result_with_message("No challenge parameter in request from client");
     }
 
     // Prepare output buffer

--- a/src/win32/kerberos_sspi.cc
+++ b/src/win32/kerberos_sspi.cc
@@ -348,7 +348,7 @@ auth_sspi_server_step(sspi_server_state* state, const char* challenge)
     // Prepare output buffer
     OutSecBuff.cbBuffer = SSPI_MAX_TOKEN_SIZE;
     OutSecBuff.BufferType = SECBUFFER_TOKEN;
-    OutSecBuff.pvBuffer = malloc(SSPI_MAX_TOKEN_SIZE);;
+    OutSecBuff.pvBuffer = malloc(SSPI_MAX_TOKEN_SIZE);
 
     OutBuffDesc.ulVersion = SECBUFFER_VERSION;
     OutBuffDesc.cBuffers = 1;
@@ -412,8 +412,12 @@ auth_sspi_server_step(sspi_server_state* state, const char* challenge)
     // Continue if applicable.
     if (ss == SEC_I_CONTINUE_NEEDED) {
         state->response = base64_encode((const SEC_CHAR*)OutSecBuff.pvBuffer, OutSecBuff.cbBuffer);
+        if (!state->response) {
+            ret = sspi_error_result_with_message("Unable to base64 encode response message");
+        } else {
+            ret = sspi_success_result(AUTH_GSS_CONTINUE);
+        }
 
-        ret = sspi_success_result(AUTH_GSS_CONTINUE);
         goto end;
     }
 
@@ -474,7 +478,7 @@ auth_sspi_client_unwrap(sspi_client_state* state, SEC_CHAR* challenge) {
     if (wrapBufs[1].cbBuffer) {
         state->response = base64_encode((const SEC_CHAR*)wrapBufs[1].pvBuffer, wrapBufs[1].cbBuffer);
         if (!state->response) {
-            result = sspi_error_result_with_message("Unable to base65 encode decrypted message");
+            result = sspi_error_result_with_message("Unable to base64 encode decrypted message");
             goto done;
         }
     }

--- a/src/win32/kerberos_sspi.cc
+++ b/src/win32/kerberos_sspi.cc
@@ -428,9 +428,13 @@ auth_sspi_server_step(sspi_server_state* state, const char* challenge)
         goto end;
     }
 
-    if (ss > 0)
-    {
-        ret = sspi_error_result_with_message("AcceptSecurityContext failed");
+    // Clear the context when reached an invalid/error state that cannot be handled
+    if (ss != SEC_E_OK) {
+        ret = sspi_error_result(ss, "AcceptSecurityContext failed");
+        if (SecIsValidHandle(&state->ctx)) {
+            DeleteSecurityContext(&state->ctx);
+            SecInvalidateHandle(&state->ctx);
+        }
         goto end;
     }
 

--- a/src/win32/kerberos_sspi.cc
+++ b/src/win32/kerberos_sspi.cc
@@ -332,6 +332,9 @@ auth_sspi_server_step(sspi_server_state* state, const char* challenge)
         // Prepare input buffer
         DWORD len;
         InSecBuff.pvBuffer = base64_decode(challenge, &len);
+        if (!InSecBuff.pvBuffer) {
+            return sspi_error_result_with_message("Unable to base64 decode challenge");
+        }
         InSecBuff.cbBuffer = len;
         InSecBuff.BufferType = SECBUFFER_TOKEN;
 

--- a/src/win32/kerberos_sspi.cc
+++ b/src/win32/kerberos_sspi.cc
@@ -349,6 +349,10 @@ auth_sspi_server_step(sspi_server_state* state, const char* challenge)
     OutSecBuff.cbBuffer = SSPI_MAX_TOKEN_SIZE;
     OutSecBuff.BufferType = SECBUFFER_TOKEN;
     OutSecBuff.pvBuffer = malloc(SSPI_MAX_TOKEN_SIZE);
+    if (OutSecBuff.pvBuffer == NULL) {
+        ret = sspi_error_result_with_message("Unable to allocate memory for output buffer");
+        goto end;
+    }
 
     OutBuffDesc.ulVersion = SECBUFFER_VERSION;
     OutBuffDesc.cBuffers = 1;

--- a/src/win32/kerberos_sspi.h
+++ b/src/win32/kerberos_sspi.h
@@ -74,5 +74,6 @@ sspi_result* auth_sspi_server_init(WCHAR* service,
                                    sspi_server_state* state);
 
 sspi_result* auth_sspi_client_step(sspi_client_state* state, SEC_CHAR* challenge, SecPkgContext_Bindings* sec_pkg_context_bindings);
+sspi_result* auth_sspi_server_step(sspi_server_state* state, const char* challenge);
 sspi_result* auth_sspi_client_unwrap(sspi_client_state* state, SEC_CHAR* challenge);
 sspi_result* auth_sspi_client_wrap(sspi_client_state* state, SEC_CHAR* data, SEC_CHAR* user, ULONG ulen, INT protect);

--- a/src/win32/kerberos_sspi.h
+++ b/src/win32/kerberos_sspi.h
@@ -45,14 +45,20 @@ typedef struct {
 } sspi_client_state;
 
 typedef struct {
-    WCHAR* username;
-    WCHAR* response;
+    CredHandle cred;
+    CtxtHandle ctx;
+    SEC_CHAR* response;
+    SEC_CHAR* username;
     BOOL context_complete;
     char* targetname;
 } sspi_server_state;
 
 sspi_client_state* sspi_client_state_new();
+sspi_server_state* sspi_server_state_new();
+
 VOID auth_sspi_client_clean(sspi_client_state* state);
+VOID auth_sspi_server_clean(sspi_server_state* state);
+
 sspi_result* auth_sspi_client_init(WCHAR* service,
                                    ULONG flags,
                                    WCHAR* user,
@@ -63,6 +69,9 @@ sspi_result* auth_sspi_client_init(WCHAR* service,
                                    ULONG plen,
                                    WCHAR* mechoid,
                                    sspi_client_state* state);
+
+sspi_result* auth_sspi_server_init(WCHAR* service,
+                                   sspi_server_state* state);
 
 sspi_result* auth_sspi_client_step(sspi_client_state* state, SEC_CHAR* challenge, SecPkgContext_Bindings* sec_pkg_context_bindings);
 sspi_result* auth_sspi_client_unwrap(sspi_client_state* state, SEC_CHAR* challenge);

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -126,7 +126,28 @@ NAN_METHOD(KerberosServer::Step) {
     KerberosServer* server = Nan::ObjectWrap::Unwrap<KerberosServer>(info.This());
     std::string challenge(*Nan::Utf8String(info[0]));
     Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
-    Nan::ThrowError("`KerberosServer::Step` is not implemented yet for windows");
+
+    KerberosWorker::Run(callback, "kerberos:ServerStep", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
+        std::shared_ptr<sspi_result> result(
+            auth_sspi_server_step(server->state(), challenge.c_str()), ResultDeleter);
+
+        return onFinished([=](KerberosWorker* worker) {
+            Nan::HandleScope scope;
+            if (result->code == AUTH_GSS_ERROR) {
+                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
+                worker->Call(2, argv);
+                return;
+            }
+
+            v8::Local<v8::Value> response = Nan::Null();
+            if (server->state()->response != NULL) {
+                response = Nan::New(server->state()->response).ToLocalChecked();
+            }
+
+            v8::Local<v8::Value> argv[] = {Nan::Null(), response};
+            worker->Call(2, argv);
+        });
+    });
 }
 
 /// Global Methods

--- a/test/kerberos_win32_tests.js
+++ b/test/kerberos_win32_tests.js
@@ -89,6 +89,22 @@ describe('Kerberos (win32)', function() {
     // this is a very basic test used to pass appveyor and provide prebuild binaries
     return kerberos.initializeClient(service, { user: username, password }).then(krbClient => {
       expect(krbClient).to.exist;
+      expect(krbClient.contextComplete).to.be.false;
+      expect(krbClient.username).to.not.exist;
+      expect(krbClient.response).to.not.exist;
+      expect(krbClient.responseConf).to.equal(0);
+    });
+  });
+
+  it('should create a kerberos server', function() {
+    // this is a very basic test used to pass appveyor and provide prebuild binaries
+    return kerberos.initializeServer(service, (err, server) => {
+        expect(err).to.not.exist;
+        expect(server).to.exist;
+        expect(server.contextComplete).to.be.false;
+        expect(server.username).to.not.exist;
+        expect(server.response).to.not.exist;
+        expect(server.targetName).to.not.exist;
     });
   });
 


### PR DESCRIPTION
This pull request adds Windows support for the Kerberos library InitializeServer and Step methods.

SSPI and Kerberos is somewhat new to me, so please review with care.

A few notes about what I did:
* I added the ImpersonateSecurityContext so it is still posible to obtain a username even if not in a domain.
* I did not add checking for (ss == SEC_I_COMPLETE_NEEDED || ss == SEC_I_COMPLETE_AND_CONTINUE) to do a CompleteAuthToken after the AcceptSecurityContext. I never saw this happened and it is also unclear from the documentation if it applies.
* I chose to use the SecIsValidHandle and SecInvalidateHandle functions to check for valid handles (instead of state->haveCtx and state->haveCred).