### PR TITLE
Enable z/OS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ The `kerberos` package is a C++ extension for Node.js that provides cross-platfo
   3. Launch cmd, `npm config set msvs_version 2015`
 
 **z/OS**
-- Require [IBM SDK for node.js v12.16.1 or later](https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos/purchase).
-- Install krb5 libraries for z/OS (it requires [curl for z/OS](https://www.rocketsoftware.com/product-categories/mainframe/curl-for-zos) and [gzip for z/OS](https://www.rocketsoftware.com/product-categories/mainframe/gzip-zos))
+- Install [IBM SDK for node.js v12.16.1 or later](https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos/purchase).
+- Install krb5 libraries for z/OS (which requires [curl for z/OS](https://www.rocketsoftware.com/product-categories/mainframe/curl-for-zos) and [gzip for z/OS](https://www.rocketsoftware.com/product-categories/mainframe/gzip-zos))
 ```
 _ENCODE_FILE_NEW=BINARY curl https://codeload.github.com/ibmruntimes/libkrb5-zos/tar.gz/v1.16.3-zos --output v1.16.3-zos.tar.gz
 gzip -d v1.16.3-zos.tar.gz
@@ -38,7 +38,7 @@ tar -xfUXo v1.16.3-zos.tar
 chtag -tc 819 -R ./libkrb5-zos-1.16.3-zos
 chtag -b -R ./libkrb5-zos-1.16.3-zos/lib
 ```
-- Set the following environment variable
+- Set the following environment variables
 ```
 export KRB5_HOME=/path/to/libkrb5-zos-1.16.3-zos
 export KRB5_CONFIG=/path/to/krb5.conf

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The `kerberos` package is a C++ extension for Node.js that provides cross-platfo
 
 **z/OS**
 - Install [IBM SDK for node.js v12.16.1 or later](https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos/purchase).
-- Install krb5 libraries for z/OS (which requires [curl for z/OS](https://www.rocketsoftware.com/product-categories/mainframe/curl-for-zos) and [gzip for z/OS](https://www.rocketsoftware.com/product-categories/mainframe/gzip-zos))
+- Install krb5 libraries for z/OS (which requires [curl for z/OS](https://www.rocketsoftware.com/product-categories/mainframe/curl-for-zos) and [gzip for z/OS](https://www.rocketsoftware.com/product-categories/mainframe/gzip-zos)):
 ```
 _ENCODE_FILE_NEW=BINARY curl https://codeload.github.com/ibmruntimes/libkrb5-zos/tar.gz/v1.16.3-zos --output v1.16.3-zos.tar.gz
 gzip -d v1.16.3-zos.tar.gz
@@ -38,7 +38,7 @@ tar -xfUXo v1.16.3-zos.tar
 chtag -tc 819 -R ./libkrb5-zos-1.16.3-zos
 chtag -b -R ./libkrb5-zos-1.16.3-zos/lib
 ```
-- Set the following environment variables
+- Set the following environment variables:
 ```
 export KRB5_HOME=/path/to/libkrb5-zos-1.16.3-zos
 export KRB5_CONFIG=/path/to/krb5.conf

--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ The `kerberos` package is a C++ extension for Node.js that provides cross-platfo
   2. Install [Python 2.7](https://www.python.org/downloads/) or [Miniconda 2.7](http://conda.pydata.org/miniconda.html) (`v3.x.x` is not supported), and run `npm config set python python2.7`
   3. Launch cmd, `npm config set msvs_version 2015`
 
+**z/OS**
+- Require [IBM SDK for node.js v12.16.1 or later](https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos/purchase).
+- Install krb5 libraries for z/OS (it requires [curl for z/OS](https://www.rocketsoftware.com/product-categories/mainframe/curl-for-zos) and [gzip for z/OS](https://www.rocketsoftware.com/product-categories/mainframe/gzip-zos))
+```
+_ENCODE_FILE_NEW=BINARY curl https://codeload.github.com/ibmruntimes/libkrb5-zos/tar.gz/v1.16.3-zos --output v1.16.3-zos.tar.gz
+gzip -d v1.16.3-zos.tar.gz
+tar -xfUXo v1.16.3-zos.tar
+chtag -tc 819 -R ./libkrb5-zos-1.16.3-zos
+chtag -b -R ./libkrb5-zos-1.16.3-zos/lib
+```
+- Set the following environment variable
+```
+export KRB5_HOME=/path/to/libkrb5-zos-1.16.3-zos
+export KRB5_CONFIG=/path/to/krb5.conf
+```
+
 ### Installation
 
 Now you can install `kerberos` with the following:

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,7 @@
         'src/kerberos.cc'
       ],
       'conditions': [
-        ['OS=="mac" or OS=="linux"', {
+        ['OS=="mac" or OS=="linux" or OS=="zos"', {
           'sources': [
             'src/unix/base64.cc',
             'src/unix/kerberos_gss.cc',
@@ -42,6 +42,21 @@
             'OTHER_LDFLAGS': [ '-stdlib=libc++' ],
             'MACOSX_DEPLOYMENT_TARGET': "10.7"
           }
+        }],
+        ['OS=="zos"', {
+            'include_dirs': [
+                '$(KRB5_HOME)/include/',
+                '$(KRB5_HOME)/include/gssapi/'
+            ],
+            'libraries': [
+                '$(KRB5_HOME)/lib/libgssrpc.a',
+                '$(KRB5_HOME)/lib/libgssapi_krb5.a',
+                '$(KRB5_HOME)/lib/libkrb5.a',
+                '$(KRB5_HOME)/lib/libk5crypto.a',
+                '$(KRB5_HOME)/lib/libcom_err.a',
+                '$(KRB5_HOME)/lib/libkrb5support.a'
+            ],
+            "libraries!": ["-lkrb5", "-lgssapi_krb5"]
         }]
       ]
     }

--- a/binding.gyp
+++ b/binding.gyp
@@ -44,19 +44,19 @@
           }
         }],
         ['OS=="zos"', {
-            'include_dirs': [
-                '$(KRB5_HOME)/include/',
-                '$(KRB5_HOME)/include/gssapi/'
-            ],
-            'libraries': [
-                '$(KRB5_HOME)/lib/libgssrpc.a',
-                '$(KRB5_HOME)/lib/libgssapi_krb5.a',
-                '$(KRB5_HOME)/lib/libkrb5.a',
-                '$(KRB5_HOME)/lib/libk5crypto.a',
-                '$(KRB5_HOME)/lib/libcom_err.a',
-                '$(KRB5_HOME)/lib/libkrb5support.a'
-            ],
-            "libraries!": ["-lkrb5", "-lgssapi_krb5"]
+          'include_dirs': [
+            '$(KRB5_HOME)/include/',
+            '$(KRB5_HOME)/include/gssapi/'
+          ],
+          'libraries': [
+            '$(KRB5_HOME)/lib/libgssrpc.a',
+            '$(KRB5_HOME)/lib/libgssapi_krb5.a',
+            '$(KRB5_HOME)/lib/libkrb5.a',
+            '$(KRB5_HOME)/lib/libk5crypto.a',
+            '$(KRB5_HOME)/lib/libcom_err.a',
+            '$(KRB5_HOME)/lib/libkrb5support.a'
+          ],
+          "libraries!": ["-lkrb5", "-lgssapi_krb5"]
         }]
       ]
     }

--- a/installScript.js
+++ b/installScript.js
@@ -9,7 +9,8 @@ if (process.env.NODE_ENV !== 'production') {
   try {
     require('prettier');
     Object.keys(platformDevDependencies).forEach(d => {
-      const { version, targets } = platformDevDependencies[d];
+      const version = platformDevDependencies[d].version;
+      const targets = platformDevDependencies[d].targets;
       if (targets.includes(os.type())) {
         execSync(`npm install --no-save ${d}@${version}`, { stdio: ['ignore', 'ignore', 'inherit'] });
       }

--- a/installScript.js
+++ b/installScript.js
@@ -1,16 +1,17 @@
 'use strict';
 const os = require('os');
-const exec = require('child_process').exec;
 const execSync = require('child_process').execSync;
 const platformDevDependencies = require('./package.json').platformDevDependencies;
 
+// Install platform specific devDependencies using custom key "platformDevDependencies"
+// in package.json
 if (process.env.NODE_ENV !== 'production') {
     try {
         require('prettier');
         Object.keys(platformDevDependencies).forEach(d => {
             const { version, targets } = platformDevDependencies[d];
             if (targets.includes(os.type())) {
-                execSync(`npm install --no-save ${d}@${version}`, { stdio: 'inherit' });
+                execSync(`npm install --no-save ${d}@${version} > /dev/null`, { stdio: 'inherit' });
             }
         });
     } catch (e) {}

--- a/installScript.js
+++ b/installScript.js
@@ -7,7 +7,7 @@ const platformDevDependencies = require('./package.json').platformDevDependencie
 if (process.env.NODE_ENV !== 'production') {
     try {
         require('prettier');
-        Objects.keys(platformDevDependencies).forEach(d => {
+        Object.keys(platformDevDependencies).forEach(d => {
             const { version, targets } = platformDevDependencies[d];
             if (targets.includes(os.type())) {
                 execSync(`npm install --no-save ${d}@${version}`, { stdio: 'inherit' });

--- a/installScript.js
+++ b/installScript.js
@@ -6,14 +6,14 @@ const platformDevDependencies = require('./package.json').platformDevDependencie
 // Install platform specific devDependencies using custom key "platformDevDependencies"
 // in package.json
 if (process.env.NODE_ENV !== 'production') {
-    try {
-        require('prettier');
-        Object.keys(platformDevDependencies).forEach(d => {
-            const { version, targets } = platformDevDependencies[d];
-            if (targets.includes(os.type())) {
-                execSync(`npm install --no-save ${d}@${version} > /dev/null`, { stdio: 'inherit' });
-            }
-        });
-    } catch (e) {}
+  try {
+    require('prettier');
+    Object.keys(platformDevDependencies).forEach(d => {
+      const { version, targets } = platformDevDependencies[d];
+      if (targets.includes(os.type())) {
+        execSync(`npm install --no-save ${d}@${version}`, { stdio: ['ignore', 'ignore', 'inherit'] });
+      }
+    });
+  } catch (e) {}
 }
 execSync("prebuild-install || node-gyp rebuild", { stdio: 'inherit' });

--- a/installScript.js
+++ b/installScript.js
@@ -11,7 +11,7 @@ if (process.env.NODE_ENV !== 'production') {
     Object.keys(platformDevDependencies).forEach(d => {
       const version = platformDevDependencies[d].version;
       const targets = platformDevDependencies[d].targets;
-      if (targets.includes(os.type())) {
+      if (targets.indexOf(os.type()) > -1) {
         execSync(`npm install --no-save ${d}@${version}`, { stdio: ['ignore', 'ignore', 'inherit'] });
       }
     });

--- a/installScript.js
+++ b/installScript.js
@@ -1,0 +1,18 @@
+'use strict';
+const os = require('os');
+const exec = require('child_process').exec;
+const execSync = require('child_process').execSync;
+const platformDevDependencies = require('./package.json').platformDevDependencies;
+
+if (process.env.NODE_ENV !== 'production') {
+    try {
+        require('prettier');
+        Objects.keys(platformDevDependencies).forEach(d => {
+            const { version, targets } = platformDevDependencies[d];
+            if (targets.includes(os.type())) {
+                execSync(`npm install --no-save ${d}@${version}`, { stdio: 'inherit' });
+            }
+        });
+    } catch (e) {}
+}
+execSync("prebuild-install || node-gyp rebuild", { stdio: 'inherit' });

--- a/package.json
+++ b/package.json
@@ -31,11 +31,20 @@
     "prebuild-ci": "^2.2.3",
     "prettier": "^1.17.1",
     "request": "^2.88.0",
-    "segfault-handler": "^1.2.0",
     "standard-version": "^4.4.0"
   },
+  "platformDevDependencies": {
+    "segfault-handler": {
+      "version": "^1.2.0",
+      "targets": [
+        "Linux",
+        "Darwin",
+        "Windows_NT"
+      ]
+    }
+  },
   "scripts": {
-    "install": "prebuild-install || node-gyp rebuild",
+    "install": "node installScript.js",
     "format-cxx": "git-clang-format",
     "format-js": "prettier --print-width 100 --tab-width 2 --single-quote --write index.js 'test/**/*.js' 'lib/**/*.js'",
     "lint": "eslint index.js lib test",

--- a/src/kerberos_common.h
+++ b/src/kerberos_common.h
@@ -3,7 +3,7 @@
 
 #include <nan.h>
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__MVS__)
 #include "unix/kerberos_gss.h"
 
 typedef gss_client_state krb_client_state;

--- a/test/kerberos_tests.js
+++ b/test/kerberos_tests.js
@@ -4,8 +4,10 @@ const request = require('request');
 const chai = require('chai');
 const expect = chai.expect;
 const os = require('os');
-const SegfaultHandler = require('segfault-handler');
-SegfaultHandler.registerHandler();
+if (os.type() !== 'OS/390') {
+    const SegfaultHandler = require('segfault-handler');
+    SegfaultHandler.registerHandler();
+}
 chai.use(require('chai-string'));
 
 // environment variables

--- a/test/kerberos_tests.js
+++ b/test/kerberos_tests.js
@@ -5,8 +5,8 @@ const chai = require('chai');
 const expect = chai.expect;
 const os = require('os');
 if (os.type() !== 'OS/390') {
-    const SegfaultHandler = require('segfault-handler');
-    SegfaultHandler.registerHandler();
+  const SegfaultHandler = require('segfault-handler');
+  SegfaultHandler.registerHandler();
 }
 chai.use(require('chai-string'));
 

--- a/test/kerberos_win32_tests.js
+++ b/test/kerberos_win32_tests.js
@@ -4,8 +4,8 @@ const MongoClient = require('mongodb').MongoClient;
 const expect = require('chai').expect;
 const os = require('os');
 if (os.type() !== 'OS/390') {
-    const SegfaultHandler = require('segfault-handler');
-    SegfaultHandler.registerHandler();
+  const SegfaultHandler = require('segfault-handler');
+  SegfaultHandler.registerHandler();
 }
 
 const password = process.env.KERBEROS_PASSWORD;

--- a/test/kerberos_win32_tests.js
+++ b/test/kerberos_win32_tests.js
@@ -3,8 +3,10 @@ const kerberos = require('..');
 const MongoClient = require('mongodb').MongoClient;
 const expect = require('chai').expect;
 const os = require('os');
-const SegfaultHandler = require('segfault-handler');
-SegfaultHandler.registerHandler();
+if (os.type() !== 'OS/390') {
+    const SegfaultHandler = require('segfault-handler');
+    SegfaultHandler.registerHandler();
+}
 
 const password = process.env.KERBEROS_PASSWORD;
 const realm = process.env.KERBEROS_REALM;


### PR DESCRIPTION
In z/OS, user would need to install a ported [krb5 libraries](https://github.com/ibmruntimes/libkrb5-zos) in order to install this npm. Also z/OS doesn't support `segfault-handler` npm, so I would need to exclude it when building in package.json, but since npm doesn't have official way to install dependencies based on platform. There are two workaround I thought of:

1. Introduce a script to call when npm install, and only install it if it is not in production environment and the platform is a supported platform.
2. Write instruction on README.md to tell user manually modify package.json

Currently this PR is using workaround 1. However, there is an issue with this workaround, which `npm ls` will not show module in the custom object platformDevDependencies.