### PR TITLE
fix: roll back node-abi until lgeiger/node-abi#90 is resolved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3104,9 +3104,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
-      "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.18.0.tgz",
+      "integrity": "sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==",
       "dev": true,
       "requires": {
         "semver": "^5.4.1"


### PR DESCRIPTION
## Description

lgeiger/node-abi#90 currently breaks our prebuilds, this PR rolls it
back to a working version directly in the `package-lock.json` as a
temporary fix until the issue is resolved.

**What changed?**
