### PR TITLE
chore(build): make addon buildable as static library

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,7 @@
   'targets': [
     {
       'target_name': 'kerberos',
+      'type': 'loadable_module',
       'include_dirs': [ '<!(node -e "require(\'nan\')")' ],
       'sources': [
         'src/kerberos.cc'
@@ -25,7 +26,16 @@
               '-lkrb5',
               '-lgssapi_krb5'
             ]
-          }
+          },
+          'conditions': [
+            ['_type=="static_library"', {
+              'link_settings': {
+                'libraries': [
+                  '-lcom_err'
+                ]
+              }
+            }]
+          ]
         }],
         ['OS=="win"',  {
           'sources': [
@@ -34,9 +44,9 @@
           ],
           'link_settings': {
             'libraries': [
-              'crypt32.lib',
-              'secur32.lib',
-              'Shlwapi.lib'
+              '-lcrypt32',
+              '-lsecur32',
+              '-lShlwapi'
             ]
           }
         }]


### PR DESCRIPTION
## Description

- Require libcom_err when building a static library
  because the code accesses `error_message()` which
  comes from it
- Use `-l` prefix for included libs for Windows

The goal here is to bundle this library as part of the `mongosh`
binary once we start enabling kerberos functionality in it.
I figured that opening a pull request early was a good idea so that
we might not need to wait for another kerberos release once we
start the actual work itself :)