### PR TITLE
chore(deps): bump node-abi from 2.18.0 to 2.26.0

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,11 +8,7 @@
         'src/kerberos.cc'
       ],
       'xcode_settings': {
-        'MACOSX_DEPLOYMENT_TARGET': '10.12',
-        'OTHER_CFLAGS': [
-          "-std=c++11",
-          "-stdlib=libc++"
-        ],
+        'MACOSX_DEPLOYMENT_TARGET': '10.12'
       },
       'conditions': [
         ['OS=="mac" or OS=="linux"', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3360,9 +3360,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.18.0.tgz",
-      "integrity": "sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.26.0.tgz",
+      "integrity": "sha512-ag/Vos/mXXpWLLAYWsAoQdgS+gW7IwvgMLOgqopm/DbzAjazLltzgzpVMsFlgmo9TzG5hGXeaBZx2AI731RIsQ==",
       "dev": true,
       "requires": {
         "semver": "^5.4.1"


### PR DESCRIPTION
- Undoes PR #118 
- Fixes issue #121 

