### PR TITLE
fix(NODE-2129): fix sporadic AcquireCredentialsHandle error

### DIFF
--- a/src/win32/kerberos_sspi.cc
+++ b/src/win32/kerberos_sspi.cc
@@ -54,7 +54,7 @@ auth_sspi_client_init(WCHAR* service,
                       WCHAR* mechoid,
                       sspi_client_state* state) {
     SECURITY_STATUS status;
-    SEC_WINNT_AUTH_IDENTITY_W authIdentity;
+    SEC_WINNT_AUTH_IDENTITY_W authIdentity{};
     TimeStamp ignored;
 
     state->response = NULL;

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -12,11 +12,14 @@
 #define GSS_C_REPLAY_FLAG 4
 #define GSS_C_SEQUENCE_FLAG 8
 
-const wchar_t* to_wstring(const char *bytes) {
-    unsigned int sizeOfStr = MultiByteToWideChar(CP_UTF8, 0, bytes, -1, NULL, 0);
-    wchar_t *output = new wchar_t[sizeOfStr];
-    MultiByteToWideChar(CP_UTF8, 0, bytes, -1, output, sizeOfStr);
-    return output;
+const std::wstring to_wstring(const char *bytes) {
+    DWORD sizeOfStr = MultiByteToWideChar(CP_UTF8, 0, bytes, -1, NULL, 0);
+    assert(sizeOfStr > 0);
+    std::wstring arg(sizeOfStr, '\0');
+    DWORD result = MultiByteToWideChar(CP_UTF8, 0, bytes, -1, &arg[0], sizeOfStr);
+    assert(result > 0);
+    arg.resize(result - 1);
+    return arg;
 }
 
 NAN_INLINE std::wstring WStringOptionValue(v8::Local<v8::Object> options, const char* _key) {
@@ -31,7 +34,7 @@ NAN_INLINE std::wstring WStringOptionValue(v8::Local<v8::Object> options, const 
       return std::wstring();
     }
 
-    return std::wstring(to_wstring(*(Nan::Utf8String(value))));
+    return to_wstring(*(Nan::Utf8String(value)));
 }
 
 /// KerberosClient
@@ -137,7 +140,7 @@ NAN_METHOD(KerberosServer::Step) {
 
 /// Global Methods
 NAN_METHOD(InitializeClient) {
-    std::wstring service(to_wstring(*(Nan::Utf8String(info[0]))));
+    std::wstring service = to_wstring(*(Nan::Utf8String(info[0])));
     v8::Local<v8::Object> options = Nan::To<v8::Object>(info[1]).ToLocalChecked();
     Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[2]).ToLocalChecked());
 


### PR DESCRIPTION
Fixes a sporadic error that occurred when calling the `AcquireCredentialsHandleW` SSPI function. This was caused by uninitialized struct members. The `authIdentity` variable was _allocated_ on the stack but not initialized. Depending on the stack's state, that caused the `authIdentity.DomainLength` or potentially the `authIdentity.Domain` members to have unpredictable content. Ensuring proper nulled initialization fixes this.

This PR also includes a fix for a memory leak in the `to_wstring` function. The allocated `output` array was never `delete`ed.

We tested this fix as part of `mongosh` in a Windows environment with Kerberos.

@addaleax 🙇 