### PR TITLE
chore(NODE-3500): clean up various bugs and memory leaks

### DIFF
--- a/src/kerberos_common.h
+++ b/src/kerberos_common.h
@@ -1,5 +1,5 @@
-#ifndef COMMON_H
-#define COMMON_H
+#ifndef KERBEROS_COMMON_H
+#define KERBEROS_COMMON_H
 
 #include <nan.h>
 

--- a/src/kerberos_common.h
+++ b/src/kerberos_common.h
@@ -17,11 +17,6 @@ typedef sspi_server_state krb_server_state;
 typedef sspi_result krb_result;
 #endif
 
-// Provide a default custom delter for the `gss_result` type
-inline void ResultDeleter(krb_result* result) {
-  free(result);
-}
-
 // Useful methods for optional value handling
 NAN_INLINE std::string StringOptionValue(v8::Local<v8::Object> options, const char* _key) {
     Nan::HandleScope scope;

--- a/src/kerberos_worker.h
+++ b/src/kerberos_worker.h
@@ -1,5 +1,5 @@
-#ifndef ASYNC_WORKER_H
-#define ASYNC_WORKER_H
+#ifndef KERBEROS_ASYNC_WORKER_H
+#define KERBEROS_ASYNC_WORKER_H
 
 #include <functional>
 #include <nan.h>

--- a/src/unix/base64.cc
+++ b/src/unix/base64.cc
@@ -20,8 +20,8 @@
 #include <string.h>
 
 // base64 tables
-static char basis_64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-static signed char index_64[128] = {
+static const char basis_64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static const signed char index_64[128] = {
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62,
     -1, -1, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1, -1, 0,

--- a/src/unix/kerberos_gss.cc
+++ b/src/unix/kerberos_gss.cc
@@ -763,8 +763,8 @@ static gss_result* gss_error_result(OM_uint32 err_maj, OM_uint32 err_min) {
 
     result = (gss_result*)malloc(sizeof(gss_result));
     result->code = AUTH_GSS_ERROR;
-    result->message = (char*)malloc(sizeof(char) * 1024 + 2);
-    sprintf(result->message, "%s: %s", buf_maj, buf_min);
+    result->message = (char*)malloc(strlen(buf_maj) + strlen(buf_min) + 3);
+    snprintf(result->message, strlen(buf_maj) + strlen(buf_min) + 3, "%s: %s", buf_maj, buf_min);
 
     return result;
 }
@@ -780,7 +780,7 @@ static gss_result* gss_error_result_with_message_and_code(const char* message, i
     gss_result* result = (gss_result*)malloc(sizeof(gss_result));
     result->code = AUTH_GSS_ERROR;
     result->message = (char*)malloc(strlen(message) + 20);
-    sprintf(result->message, "%s (%d)", message, code);
+    snprintf(result->message, strlen(message) + 20, "%s (%d)", message, code);
     return result;
 }
 

--- a/src/unix/kerberos_gss.cc
+++ b/src/unix/kerberos_gss.cc
@@ -422,9 +422,10 @@ gss_result* authenticate_gss_client_wrap(gss_client_state* state,
         memcpy(buf, &buf_size, 4);
         buf[0] = GSS_AUTH_P_NONE;
         // server decides if principal can log in as user
-        strncpy(buf + 4, user, sizeof(buf) - 4);
+        strncpy(buf + 4, user, sizeof(buf) - 5);
+        buf[sizeof(buf) - 1] = '\0';
         input_token.value = buf;
-        input_token.length = 4 + strlen(user);
+        input_token.length = 4 + strlen(buf + 4);
     }
 
     // Do GSSAPI wrap
@@ -747,13 +748,15 @@ static gss_result* gss_error_result(OM_uint32 err_maj, OM_uint32 err_min) {
             &min_stat, err_maj, GSS_C_GSS_CODE, GSS_C_NO_OID, &msg_ctx, &status_string);
         if (GSS_ERROR(maj_stat))
             break;
-        strncpy(buf_maj, (char*)status_string.value, sizeof(buf_maj));
+        strncpy(buf_maj, (char*)status_string.value, sizeof(buf_maj) - 1);
+        buf_maj[sizeof(buf_maj) - 1] = '\0';
         gss_release_buffer(&min_stat, &status_string);
 
         maj_stat = gss_display_status(
             &min_stat, err_min, GSS_C_MECH_CODE, GSS_C_NULL_OID, &msg_ctx, &status_string);
         if (!GSS_ERROR(maj_stat)) {
-            strncpy(buf_min, (char*)status_string.value, sizeof(buf_min));
+            strncpy(buf_min, (char*)status_string.value, sizeof(buf_min) - 1);
+            buf_min[sizeof(buf_min) - 1] = '\0';
             gss_release_buffer(&min_stat, &status_string);
         }
     } while (!GSS_ERROR(maj_stat) && msg_ctx != 0);

--- a/src/unix/kerberos_gss.h
+++ b/src/unix/kerberos_gss.h
@@ -23,6 +23,8 @@ extern "C" {
     #include <gssapi/gssapi_krb5.h>
 }
 
+#include <string>
+
 inline const char* krb5_get_err_text(const krb5_context&, krb5_error_code code) {
     return error_message(code);
 }
@@ -37,8 +39,8 @@ inline const char* krb5_get_err_text(const krb5_context&, krb5_error_code code) 
 
 typedef struct {
     int code;
-    char* message;
-    char* data;
+    std::string message;
+    std::string data;
 } gss_result;
 
 typedef struct {
@@ -68,31 +70,31 @@ typedef struct {
 gss_client_state* gss_client_state_new();
 gss_server_state* gss_server_state_new();
 
-gss_result* server_principal_details(const char* service, const char* hostname);
+gss_result server_principal_details(const char* service, const char* hostname);
 
-gss_result* authenticate_gss_client_init(const char* service,
-                                         const char* principal,
-                                         long int gss_flags,
-                                         gss_server_state* delegatestate,
-                                         gss_OID mech_oid,
-                                         gss_client_state* state);
+gss_result authenticate_gss_client_init(const char* service,
+                                        const char* principal,
+                                        long int gss_flags,
+                                        gss_server_state* delegatestate,
+                                        gss_OID mech_oid,
+                                        gss_client_state* state);
 
 int authenticate_gss_client_clean(gss_client_state* state);
-gss_result* authenticate_gss_client_step(gss_client_state* state,
-                                         const char* challenge,
-                                         struct gss_channel_bindings_struct* channel_bindings);
-gss_result* authenticate_gss_client_unwrap(gss_client_state* state, const char* challenge);
-gss_result* authenticate_gss_client_wrap(gss_client_state* state,
-                                         const char* challenge,
-                                         const char* user,
-                                         int protect);
-gss_result* authenticate_gss_server_init(const char* service, gss_server_state* state);
+gss_result authenticate_gss_client_step(gss_client_state* state,
+                                        const char* challenge,
+                                        struct gss_channel_bindings_struct* channel_bindings);
+gss_result authenticate_gss_client_unwrap(gss_client_state* state, const char* challenge);
+gss_result authenticate_gss_client_wrap(gss_client_state* state,
+                                        const char* challenge,
+                                        const char* user,
+                                        int protect);
+gss_result authenticate_gss_server_init(const char* service, gss_server_state* state);
 int authenticate_gss_server_clean(gss_server_state* state);
-gss_result* authenticate_gss_server_step(gss_server_state* state, const char* challenge);
+gss_result authenticate_gss_server_step(gss_server_state* state, const char* challenge);
 
-gss_result* authenticate_user_krb5pwd(const char* user,
-                                      const char* pswd,
-                                      const char* service,
-                                      const char* default_realm);
+gss_result authenticate_user_krb5pwd(const char* user,
+                                     const char* pswd,
+                                     const char* service,
+                                     const char* default_realm);
 
 #endif

--- a/src/unix/kerberos_gss.h
+++ b/src/unix/kerberos_gss.h
@@ -20,7 +20,9 @@ extern "C" {
     #include <gssapi/gssapi_krb5.h>
 }
 
-#define krb5_get_err_text(context, code) error_message(code)
+inline const char* krb5_get_err_text(const krb5_context&, krb5_error_code code) {
+    return error_message(code);
+}
 
 #define AUTH_GSS_ERROR -1
 #define AUTH_GSS_COMPLETE 1

--- a/src/unix/kerberos_gss.h
+++ b/src/unix/kerberos_gss.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  **/
 
+#ifndef KERBEROS_GSS_H
+#define KERBEROS_GSS_H
+
 extern "C" {
     #include <gssapi/gssapi.h>
     #include <gssapi/gssapi_generic.h>
@@ -91,3 +94,5 @@ gss_result* authenticate_user_krb5pwd(const char* user,
                                       const char* pswd,
                                       const char* service,
                                       const char* default_realm);
+
+#endif

--- a/src/unix/kerberos_unix.cc
+++ b/src/unix/kerberos_unix.cc
@@ -26,13 +26,13 @@ NAN_METHOD(KerberosClient::Step) {
     Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
 
     KerberosWorker::Run(callback, "kerberos:ClientStep", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
-        std::shared_ptr<gss_result> result(
-            authenticate_gss_client_step(client->state(), challenge.c_str(), NULL), ResultDeleter);
+        gss_result result =
+            authenticate_gss_client_step(client->state(), challenge.c_str(), NULL);
 
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
-            if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
+            if (result.code == AUTH_GSS_ERROR) {
+                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -54,13 +54,13 @@ NAN_METHOD(KerberosClient::UnwrapData) {
     Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
 
     KerberosWorker::Run(callback, "kerberos:ClientUnwrap", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
-        std::shared_ptr<gss_result> result(
-            authenticate_gss_client_unwrap(client->state(), challenge.c_str()), ResultDeleter);
+        gss_result result =
+            authenticate_gss_client_unwrap(client->state(), challenge.c_str());
 
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
-            if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
+            if (result.code == AUTH_GSS_ERROR) {
+                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -81,13 +81,13 @@ NAN_METHOD(KerberosClient::WrapData) {
     int protect = 0; // NOTE: this should be an option
 
     KerberosWorker::Run(callback, "kerberos:ClientWrap", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
-        std::shared_ptr<gss_result> result(authenticate_gss_client_wrap(
-            client->state(), challenge.c_str(), user.c_str(), protect), ResultDeleter);
+        gss_result result = authenticate_gss_client_wrap(
+            client->state(), challenge.c_str(), user.c_str(), protect);
 
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
-            if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
+            if (result.code == AUTH_GSS_ERROR) {
+                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -112,13 +112,13 @@ NAN_METHOD(KerberosServer::Step) {
     Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
 
     KerberosWorker::Run(callback, "kerberos:ServerStep", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
-        std::shared_ptr<gss_result> result(
-            authenticate_gss_server_step(server->state(), challenge.c_str()), ResultDeleter);
+        gss_result result =
+            authenticate_gss_server_step(server->state(), challenge.c_str());
 
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
-            if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
+            if (result.code == AUTH_GSS_ERROR) {
+                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -153,19 +153,20 @@ NAN_METHOD(InitializeClient) {
 
     KerberosWorker::Run(callback, "kerberos:InitializeClient", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         gss_client_state* client_state = gss_client_state_new();
-        std::shared_ptr<gss_result> result(authenticate_gss_client_init(
-            service.c_str(), principal.c_str(), gss_flags, NULL, mech_oid, client_state), ResultDeleter);
+        gss_result result = authenticate_gss_client_init(
+            service.c_str(), principal.c_str(), gss_flags, NULL, mech_oid, client_state);
 
+        // XXX The comment is wrong
         // must clean up state if we won't be using it, smart pointers won't help here unfortunately
         // because we can't `release` a shared pointer.
-        if (result->code == AUTH_GSS_ERROR) {
+        if (result.code == AUTH_GSS_ERROR) {
             free(client_state);
         }
 
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
-            if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
+            if (result.code == AUTH_GSS_ERROR) {
+                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -182,19 +183,20 @@ NAN_METHOD(InitializeServer) {
 
     KerberosWorker::Run(callback, "kerberos:InitializeServer", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         gss_server_state* server_state = gss_server_state_new();
-        std::shared_ptr<gss_result> result(
-            authenticate_gss_server_init(service.c_str(), server_state), ResultDeleter);
+        gss_result result =
+            authenticate_gss_server_init(service.c_str(), server_state);
 
+        // XXX ditto, the comment is wrong
         // must clean up state if we won't be using it, smart pointers won't help here unfortunately
         // because we can't `release` a shared pointer.
-        if (result->code == AUTH_GSS_ERROR) {
+        if (result.code == AUTH_GSS_ERROR) {
             free(server_state);
         }
 
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
-            if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
+            if (result.code == AUTH_GSS_ERROR) {
+                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
@@ -211,18 +213,18 @@ NAN_METHOD(PrincipalDetails) {
     Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[2]).ToLocalChecked());
 
     KerberosWorker::Run(callback, "kerberos:PrincipalDetails", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
-        std::shared_ptr<gss_result> result(
-            server_principal_details(service.c_str(), hostname.c_str()), ResultDeleter);
+        gss_result result =
+            server_principal_details(service.c_str(), hostname.c_str());
 
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
-            if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
+            if (result.code == AUTH_GSS_ERROR) {
+                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
                 worker->Call(2, argv);
                 return;
             }
 
-            v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::New(result->data).ToLocalChecked()};
+            v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::New(result.data.c_str()).ToLocalChecked()};
             worker->Call(2, argv);
         });
     });
@@ -243,13 +245,13 @@ NAN_METHOD(CheckPassword) {
     }
 
     KerberosWorker::Run(callback, "kerberos:CheckPassword", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
-        std::shared_ptr<gss_result> result(authenticate_user_krb5pwd(
-            username.c_str(), password.c_str(), service.c_str(), defaultRealm.c_str()), ResultDeleter);
+        gss_result result = authenticate_user_krb5pwd(
+            username.c_str(), password.c_str(), service.c_str(), defaultRealm.c_str());
 
         return onFinished([=](KerberosWorker* worker) {
             Nan::HandleScope scope;
-            if (result->code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result->message), Nan::Null()};
+            if (result.code == AUTH_GSS_ERROR) {
+                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
                 worker->Call(2, argv);
             } else {
                 v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::Null()};

--- a/src/win32/kerberos_sspi.cc
+++ b/src/win32/kerberos_sspi.cc
@@ -279,7 +279,7 @@ auth_sspi_client_unwrap(sspi_client_state* state, SEC_CHAR* challenge) {
     if (wrapBufs[1].cbBuffer) {
         state->response = base64_encode((const SEC_CHAR*)wrapBufs[1].pvBuffer, wrapBufs[1].cbBuffer);
         if (!state->response) {
-            result = sspi_error_result_with_message("Unable to base65 encode decrypted message");
+            result = sspi_error_result_with_message("Unable to base64 encode decrypted message");
             goto done;
         }
     }

--- a/src/win32/kerberos_sspi.cc
+++ b/src/win32/kerberos_sspi.cc
@@ -436,7 +436,7 @@ static sspi_result* sspi_success_result(int ret) {
 }
 
 static sspi_result* sspi_error_result(DWORD errCode, const SEC_CHAR* msg) {
-    SEC_CHAR* err;
+    SEC_CHAR* err = NULL;
     DWORD status;
     DWORD flags = (FORMAT_MESSAGE_ALLOCATE_BUFFER |
                    FORMAT_MESSAGE_FROM_SYSTEM |
@@ -458,6 +458,7 @@ static sspi_result* sspi_error_result(DWORD errCode, const SEC_CHAR* msg) {
     } else {
         snprintf(result->message, 1024 + 2, "%s", msg);
     }
+    LocalFree(err);
 
     return result;
 }

--- a/src/win32/kerberos_sspi.cc
+++ b/src/win32/kerberos_sspi.cc
@@ -452,11 +452,11 @@ static sspi_result* sspi_error_result(DWORD errCode, const SEC_CHAR* msg) {
 
     sspi_result* result = (sspi_result*)malloc(sizeof(sspi_result));
     result->code = AUTH_GSS_ERROR;
-    result->message = (char*)malloc(sizeof(char) * 1024 + 2);
+    result->message = (char*)malloc(1024 + 2);
     if (status) {
-        sprintf(result->message, "%s: %s", msg, err);
+        snprintf(result->message, 1024 + 2, "%s: %s", msg, err);
     } else {
-        sprintf(result->message, "%s", msg);
+        snprintf(result->message, 1024 + 2, "%s", msg);
     }
 
     return result;

--- a/src/win32/kerberos_sspi.h
+++ b/src/win32/kerberos_sspi.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef KERBEROS_SSPI_H
+#define KERBEROS_SSPI_H
+
 #define SECURITY_WIN32 1 /* Required for SSPI */
 
 #include <windows.h>
@@ -67,3 +70,5 @@ sspi_result* auth_sspi_client_init(WCHAR* service,
 sspi_result* auth_sspi_client_step(sspi_client_state* state, SEC_CHAR* challenge, SecPkgContext_Bindings* sec_pkg_context_bindings);
 sspi_result* auth_sspi_client_unwrap(sspi_client_state* state, SEC_CHAR* challenge);
 sspi_result* auth_sspi_client_wrap(sspi_client_state* state, SEC_CHAR* data, SEC_CHAR* user, ULONG ulen, INT protect);
+
+#endif

--- a/src/win32/kerberos_sspi.h
+++ b/src/win32/kerberos_sspi.h
@@ -21,6 +21,7 @@
 
 #include <windows.h>
 #include <sspi.h>
+#include <string>
 
 #define AUTH_GSS_ERROR -1
 #define AUTH_GSS_COMPLETE 1
@@ -28,8 +29,8 @@
 
 typedef struct {
     int code;
-    char* message;
-    char* data;
+    std::string message;
+    std::string data;
 } sspi_result;
 
 typedef struct {
@@ -56,7 +57,7 @@ typedef struct {
 
 sspi_client_state* sspi_client_state_new();
 VOID auth_sspi_client_clean(sspi_client_state* state);
-sspi_result* auth_sspi_client_init(WCHAR* service,
+sspi_result auth_sspi_client_init(WCHAR* service,
                                    ULONG flags,
                                    WCHAR* user,
                                    ULONG ulen,
@@ -67,8 +68,8 @@ sspi_result* auth_sspi_client_init(WCHAR* service,
                                    WCHAR* mechoid,
                                    sspi_client_state* state);
 
-sspi_result* auth_sspi_client_step(sspi_client_state* state, SEC_CHAR* challenge, SecPkgContext_Bindings* sec_pkg_context_bindings);
-sspi_result* auth_sspi_client_unwrap(sspi_client_state* state, SEC_CHAR* challenge);
-sspi_result* auth_sspi_client_wrap(sspi_client_state* state, SEC_CHAR* data, SEC_CHAR* user, ULONG ulen, INT protect);
+sspi_result auth_sspi_client_step(sspi_client_state* state, SEC_CHAR* challenge, SecPkgContext_Bindings* sec_pkg_context_bindings);
+sspi_result auth_sspi_client_unwrap(sspi_client_state* state, SEC_CHAR* challenge);
+sspi_result auth_sspi_client_wrap(sspi_client_state* state, SEC_CHAR* data, SEC_CHAR* user, ULONG ulen, INT protect);
 
 #endif

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -134,9 +134,6 @@ KerberosServer::~KerberosServer() {
 }
 
 NAN_METHOD(KerberosServer::Step) {
-    KerberosServer* server = Nan::ObjectWrap::Unwrap<KerberosServer>(info.This());
-    std::string challenge(*Nan::Utf8String(info[0]));
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
     Nan::ThrowError("`KerberosServer::Step` is not implemented yet for windows");
 }
 


### PR DESCRIPTION
Tracked through https://jira.mongodb.org/browse/NODE-3500

mongosh integration build: https://spruce.mongodb.com/version/60fff2bb2a60ed52198a5d7d/tasks + mongosh connectivity on Windows confirmed manually

---

##### chore: apply const to readonly data


##### chore: turn inline-function-like macro into inline function

This is a best practice for C++, because it makes sure that
this really behaves like a function in all cases (in particular,
that the number of times that each argument is evaluated is one
and does not depend on the function definition).

##### chore: use appropriate and consistent include guards

This is a best practice for C++, because it avoids collisions with
other headers that may be present on the system, including ones
that may be part of the standard library.

##### fix: avoid strncpy-related oob reads

`strncpy` will not 0-terminate strings if the terminator does not
fit into the target buffer. This is already handled manually in
some places, but not all; this commit rectifies that.
Additionally, if truncation does take place, we should consider
the truncated length the length of the resulting string, not the
original length.

##### chore: fix typo


##### fix: avoid sprintf-related oob writes

`sprintf` is generally considered a footgun because it makes it easy
to write insecure code; `snprintf` should always be used instead.
(The previous usage of `sprintf` in both UNIX and Windows would at
least theoretically indeed have been problematic here.)

##### fix: fix memory leak in sspi_error_result

`FORMAT_MESSAGE_ALLOCATE_BUFFER` does exactly what it says, so there
needs to be a corresponding de-allocation.

##### fix: pass results by value using C++ primitives

This cleans up the code a bit, but more importantly, the usage of
std::string avoids the memory leaks that occur due to the fact that
`ResultDeleter` would free the struct itself but not its members.

##### fix: properly clean up all client/server state instances

Some were missing the call to release the state struct itself,
some were missing the call to clean up its contents.

I’ve debated a lot whether to do something similar to the
preceding `gss_result` change, where moving to a more idiomatic
C++-based solution just resolves the issue through cleaner
code, but since that seemed like it might turn out to be a
more invasive change, I’ve only left TODO comments for this.

##### fix: remove unused code before throwing exception

Allocating the callback was a memory leak here. Since we throw
an exception anyway, remove the rest of the method.
