### PR TITLE
feat!(NODE-3472): convert to Node-API

### DIFF
--- a/.evergreen/run-prebuild.sh
+++ b/.evergreen/run-prebuild.sh
@@ -14,7 +14,6 @@ run_prebuild() {
   else
     echo "Github token detected. Running prebuild."
     npm run prebuild -- -u $NODE_GITHUB_TOKEN
-    npm run prebuild-legacy -- -u $NODE_GITHUB_TOKEN
     echo "Prebuild's successfully submitted"
   fi
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,14 +3,27 @@
     {
       'target_name': 'kerberos',
       'type': 'loadable_module',
-      'include_dirs': [ '<!(node -e "require(\'nan\')")' ],
+      'include_dirs': [  "<!(node -p \"require('node-addon-api').include_dir\")" ],
       'sources': [
         'src/kerberos.cc'
       ],
       'xcode_settings': {
+        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+        'CLANG_CXX_LIBRARY': 'libc++',
         'MACOSX_DEPLOYMENT_TARGET': '10.12'
       },
+      'cflags!': [ '-fno-exceptions' ],
+      'cflags_cc!': [ '-fno-exceptions' ],
+      'msvs_settings': {
+        'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+      },
       'conditions': [
+        ['OS=="mac"', {
+            'cflags+': ['-fvisibility=hidden'],
+            'xcode_settings': {
+              'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
+            }
+        }],
         ['OS=="mac" or OS=="linux"', {
           'sources': [
             'src/unix/base64.cc',

--- a/package-lock.json
+++ b/package-lock.json
@@ -3200,7 +3200,8 @@
     "nan": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true
     },
     "napi-build-utils": {
       "version": "1.0.2",
@@ -3238,6 +3239,11 @@
       "requires": {
         "semver": "^5.4.1"
       }
+    },
+    "node-addon-api": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.2.0.tgz",
+      "integrity": "sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q=="
     },
     "node-gyp": {
       "version": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.14.1",
+    "node-addon-api": "^4.1.0",
     "prebuild-install": "6.1.2"
   },
   "devDependencies": {
@@ -41,7 +41,7 @@
     "standard-version": "^9.3.1"
   },
   "scripts": {
-    "install": "prebuild-install || node-gyp rebuild",
+    "install": "prebuild-install --runtime napi || node-gyp rebuild",
     "format-cxx": "git-clang-format",
     "format-js": "prettier --print-width 100 --tab-width 2 --single-quote --write index.js 'test/**/*.js' 'lib/**/*.js'",
     "lint": "eslint index.js lib test",
@@ -49,9 +49,16 @@
     "test": "mocha ./test",
     "docs": "jsdoc2md --template etc/README.hbs --plugin dmd-clear --files lib/kerberos.js > README.md",
     "rebuild": "prebuild --compile",
-    "prebuild": "prebuild  --strip --verbose --all",
-    "prebuild-legacy": "prebuild  --strip --verbose --runtime node --target 4.0.0",
+    "prebuild": "prebuild --runtime napi --strip --verbose --all",
     "release": "standard-version -i HISTORY.md"
+  },
+  "engines": {
+    "node": ">=12.9.0"
+  },
+  "binary": {
+    "napi_versions": [
+      4
+    ]
   },
   "license": "Apache-2.0",
   "readmeFilename": "README.md"

--- a/src/kerberos.cc
+++ b/src/kerberos.cc
@@ -26,7 +26,7 @@ NAN_MODULE_INIT(KerberosClient::Init) {
              Nan::GetFunction(tpl).ToLocalChecked());
 }
 
-v8::Local<v8::Object> KerberosClient::NewInstance(krb_client_state* state) {
+v8::Local<v8::Object> KerberosClient::NewInstance(std::shared_ptr<krb_client_state> state) {
     Nan::EscapableHandleScope scope;
     v8::Local<v8::Function> ctor = Nan::New<v8::Function>(KerberosClient::constructor);
     v8::Local<v8::Object> object = Nan::NewInstance(ctor).ToLocalChecked();
@@ -35,9 +35,10 @@ v8::Local<v8::Object> KerberosClient::NewInstance(krb_client_state* state) {
     return scope.Escape(object);
 }
 
-KerberosClient::KerberosClient(krb_client_state* state) : _state(state) {}
+KerberosClient::KerberosClient(std::shared_ptr<krb_client_state> state)
+    : _state(state) {}
 
-krb_client_state* KerberosClient::state() const {
+std::shared_ptr<krb_client_state> KerberosClient::state() const {
     return _state;
 }
 
@@ -88,7 +89,7 @@ NAN_MODULE_INIT(KerberosServer::Init) {
              Nan::GetFunction(tpl).ToLocalChecked());
 }
 
-v8::Local<v8::Object> KerberosServer::NewInstance(krb_server_state* state) {
+v8::Local<v8::Object> KerberosServer::NewInstance(std::shared_ptr<krb_server_state> state) {
     Nan::EscapableHandleScope scope;
     v8::Local<v8::Function> ctor = Nan::New<v8::Function>(KerberosServer::constructor);
     v8::Local<v8::Object> object = Nan::NewInstance(ctor).ToLocalChecked();
@@ -97,9 +98,10 @@ v8::Local<v8::Object> KerberosServer::NewInstance(krb_server_state* state) {
     return scope.Escape(object);
 }
 
-KerberosServer::KerberosServer(krb_server_state* state) : _state(state) {}
+KerberosServer::KerberosServer(std::shared_ptr<krb_server_state> state)
+    : _state(state) {}
 
-krb_server_state* KerberosServer::state() const {
+std::shared_ptr<krb_server_state> KerberosServer::state() const {
     return _state;
 }
 

--- a/src/kerberos.h
+++ b/src/kerberos.h
@@ -7,9 +7,9 @@
 class KerberosServer : public Nan::ObjectWrap {
    public:
     static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> NewInstance(krb_server_state* state);
+    static v8::Local<v8::Object> NewInstance(std::shared_ptr<krb_server_state> state);
 
-    krb_server_state* state() const;
+    std::shared_ptr<krb_server_state> state() const;
 
    private:
     static Nan::Persistent<v8::Function> constructor;
@@ -22,18 +22,17 @@ class KerberosServer : public Nan::ObjectWrap {
     static NAN_METHOD(Step);
 
    private:
-    explicit KerberosServer(krb_server_state* server_state);
-    ~KerberosServer();
+    explicit KerberosServer(std::shared_ptr<krb_server_state> server_state);
 
-    krb_server_state* _state;
+    std::shared_ptr<krb_server_state> _state;
 };
 
 class KerberosClient : public Nan::ObjectWrap {
    public:
     static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> NewInstance(krb_client_state* state);
+    static v8::Local<v8::Object> NewInstance(std::shared_ptr<krb_client_state> state);
 
-    krb_client_state* state() const;
+    std::shared_ptr<krb_client_state> state() const;
 
    private:
     static Nan::Persistent<v8::Function> constructor;
@@ -48,10 +47,9 @@ class KerberosClient : public Nan::ObjectWrap {
     static NAN_METHOD(WrapData);
 
    private:
-    explicit KerberosClient(krb_client_state* client_state);
-    ~KerberosClient();
+    explicit KerberosClient(std::shared_ptr<krb_client_state> client_state);
 
-    krb_client_state* _state;
+    std::shared_ptr<krb_client_state> _state;
 };
 
 NAN_METHOD(PrincipalDetails);

--- a/src/kerberos_common.h
+++ b/src/kerberos_common.h
@@ -1,53 +1,22 @@
 #ifndef KERBEROS_COMMON_H
 #define KERBEROS_COMMON_H
 
-#include <nan.h>
-
 #if defined(__linux__) || defined(__APPLE__)
 #include "unix/kerberos_gss.h"
 
+namespace node_kerberos {
 typedef gss_client_state krb_client_state;
 typedef gss_server_state krb_server_state;
 typedef gss_result krb_result;
+}
 #else
 #include "win32/kerberos_sspi.h"
 
+namespace node_kerberos {
 typedef sspi_client_state krb_client_state;
 typedef sspi_server_state krb_server_state;
 typedef sspi_result krb_result;
+}
 #endif
-
-// Useful methods for optional value handling
-NAN_INLINE std::string StringOptionValue(v8::Local<v8::Object> options, const char* _key) {
-    Nan::HandleScope scope;
-    v8::Local<v8::String> key = Nan::New(_key).ToLocalChecked();
-    if (options.IsEmpty() || !Nan::Has(options, key).FromMaybe(false)) {
-      return std::string();
-    }
-
-    v8::Local<v8::Value> value = Nan::Get(options, key).ToLocalChecked();
-    if (!value->IsString()) {
-      return std::string();
-    }
-
-    return std::string(*(Nan::Utf8String(value)));
-}
-
-NAN_INLINE uint32_t UInt32OptionValue(v8::Local<v8::Object> options,
-                                      const char* _key,
-                                      uint32_t def) {
-    Nan::HandleScope scope;
-    v8::Local<v8::String> key = Nan::New(_key).ToLocalChecked();
-    if (options.IsEmpty() || !Nan::Has(options, key).FromMaybe(false)) {
-      return def;
-    }
-
-    v8::Local<v8::Value> value = Nan::Get(options, key).ToLocalChecked();
-    if (!value->IsNumber()) {
-      return def;
-    }
-
-    return value->Uint32Value(Nan::GetCurrentContext()).FromJust();
-}
 
 #endif

--- a/src/kerberos_worker.h
+++ b/src/kerberos_worker.h
@@ -2,47 +2,47 @@
 #define KERBEROS_ASYNC_WORKER_H
 
 #include <functional>
-#include <nan.h>
+#include "kerberos.h"
 
-class KerberosWorker : public Nan::AsyncWorker {
+namespace node_kerberos {
+
+class KerberosWorker final : public Napi::AsyncWorker {
  public:
+    ~KerberosWorker() {}
+
     typedef std::function<void(KerberosWorker*)>  OnFinishedHandler;
     typedef std::function<void(OnFinishedHandler)> SetOnFinishedHandler;
     typedef std::function<void(SetOnFinishedHandler)> ExecuteHandler;
 
-    explicit KerberosWorker(Nan::Callback *callback, const char* resource_name, ExecuteHandler handler)
-        : Nan::AsyncWorker(callback, resource_name), execute_handler(handler) {}
-
     template <class... T>
     void Call(T... t) {
-      callback->Call(t..., async_resource);
+      Callback().Call(t...);
     }
 
-    virtual void Execute() {
+    static void Run(Napi::Function callback, const char* resource_name, ExecuteHandler handler) {
+        auto worker = new KerberosWorker(callback, resource_name, handler);
+        worker->Queue();
+    }
+
+ protected:
+    void Execute() final {
         execute_handler([=] (OnFinishedHandler handler) {
             on_finished_handler = handler;
         });
     }
 
-    static void Run(Nan::Callback *callback, const char* resource_name, ExecuteHandler handler) {
-        Nan::TryCatch tryCatch;
-        if (tryCatch.HasCaught()) {
-            tryCatch.ReThrow();
-            return; // don't proceed in case there were any previous errors
-        }
-
-        auto worker = new KerberosWorker(callback, resource_name, handler);
-        Nan::AsyncQueueWorker(worker);
-    }
-
- protected:
-    void HandleOKCallback() {
+    void OnOK() final {
         on_finished_handler(this);
     }
 
  private:
+    explicit KerberosWorker(Napi::Function callback, const char* resource_name, ExecuteHandler handler)
+        : Napi::AsyncWorker(callback, resource_name), execute_handler(handler) {}
+
     ExecuteHandler execute_handler;
     OnFinishedHandler on_finished_handler;
 };
+
+}
 
 #endif // ASYNC_WORKER_H

--- a/src/unix/kerberos_gss.cc
+++ b/src/unix/kerberos_gss.cc
@@ -28,6 +28,8 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
+namespace node_kerberos {
+
 static gss_result gss_success_result(int ret);
 static gss_result gss_error_result(OM_uint32 err_maj, OM_uint32 err_min);
 static gss_result gss_error_result_with_message(const char* message);
@@ -733,6 +735,8 @@ static gss_result gss_error_result_with_message_and_code(const char* message, in
         std::string(message) + " (" + std::to_string(code) + ")",
         ""
     };
+}
+
 }
 
 #if defined(__clang__)

--- a/src/unix/kerberos_gss.cc
+++ b/src/unix/kerberos_gss.cc
@@ -33,26 +33,6 @@ static gss_result gss_error_result(OM_uint32 err_maj, OM_uint32 err_min);
 static gss_result gss_error_result_with_message(const char* message);
 static gss_result gss_error_result_with_message_and_code(const char* mesage, int code);
 
-gss_client_state* gss_client_state_new() {
-    gss_client_state* state = (gss_client_state*)malloc(sizeof(gss_client_state));
-    state->username = NULL;
-    state->response = NULL;
-    state->responseConf = 0;
-    state->context_complete = false;
-
-    return state;
-}
-
-gss_server_state* gss_server_state_new() {
-    gss_server_state* state = (gss_server_state*)malloc(sizeof(gss_server_state));
-    state->username = NULL;
-    state->response = NULL;
-    state->targetname = NULL;
-    state->context_complete = false;
-
-    return state;
-}
-
 gss_result server_principal_details(const char* service, const char* hostname) {
     char match[1024];
     size_t match_len = 0;
@@ -195,26 +175,17 @@ end:
     return ret;
 }
 
-int authenticate_gss_client_clean(gss_client_state* state) {
+gss_client_state::~gss_client_state() {
     OM_uint32 min_stat;
-    int ret = AUTH_GSS_COMPLETE;
 
-    if (state->context != GSS_C_NO_CONTEXT)
-        gss_delete_sec_context(&min_stat, &state->context, GSS_C_NO_BUFFER);
-    if (state->server_name != GSS_C_NO_NAME)
-        gss_release_name(&min_stat, &state->server_name);
-    if (state->client_creds != GSS_C_NO_CREDENTIAL && !(state->gss_flags & GSS_C_DELEG_FLAG))
-        gss_release_cred(&min_stat, &state->client_creds);
-    if (state->username != NULL) {
-        free(state->username);
-        state->username = NULL;
-    }
-    if (state->response != NULL) {
-        free(state->response);
-        state->response = NULL;
-    }
-
-    return ret;
+    if (context != GSS_C_NO_CONTEXT)
+        gss_delete_sec_context(&min_stat, &context, GSS_C_NO_BUFFER);
+    if (server_name != GSS_C_NO_NAME)
+        gss_release_name(&min_stat, &server_name);
+    if (client_creds != GSS_C_NO_CREDENTIAL && !(gss_flags & GSS_C_DELEG_FLAG))
+        gss_release_cred(&min_stat, &client_creds);
+    free(username);
+    free(response);
 }
 
 gss_result authenticate_gss_client_step(gss_client_state* state,
@@ -507,34 +478,22 @@ end:
     return ret;
 }
 
-int authenticate_gss_server_clean(gss_server_state* state) {
+gss_server_state::~gss_server_state() {
     OM_uint32 min_stat;
-    int ret = AUTH_GSS_COMPLETE;
 
-    if (state->context != GSS_C_NO_CONTEXT)
-        gss_delete_sec_context(&min_stat, &state->context, GSS_C_NO_BUFFER);
-    if (state->server_name != GSS_C_NO_NAME)
-        gss_release_name(&min_stat, &state->server_name);
-    if (state->client_name != GSS_C_NO_NAME)
-        gss_release_name(&min_stat, &state->client_name);
-    if (state->server_creds != GSS_C_NO_CREDENTIAL)
-        gss_release_cred(&min_stat, &state->server_creds);
-    if (state->client_creds != GSS_C_NO_CREDENTIAL)
-        gss_release_cred(&min_stat, &state->client_creds);
-    if (state->username != NULL) {
-        free(state->username);
-        state->username = NULL;
-    }
-    if (state->targetname != NULL) {
-        free(state->targetname);
-        state->targetname = NULL;
-    }
-    if (state->response != NULL) {
-        free(state->response);
-        state->response = NULL;
-    }
-
-    return ret;
+    if (context != GSS_C_NO_CONTEXT)
+        gss_delete_sec_context(&min_stat, &context, GSS_C_NO_BUFFER);
+    if (server_name != GSS_C_NO_NAME)
+        gss_release_name(&min_stat, &server_name);
+    if (client_name != GSS_C_NO_NAME)
+        gss_release_name(&min_stat, &client_name);
+    if (server_creds != GSS_C_NO_CREDENTIAL)
+        gss_release_cred(&min_stat, &server_creds);
+    if (client_creds != GSS_C_NO_CREDENTIAL)
+        gss_release_cred(&min_stat, &client_creds);
+    free(username);
+    free(targetname);
+    free(response);
 }
 
 gss_result authenticate_gss_server_step(gss_server_state* state, const char* challenge) {

--- a/src/unix/kerberos_gss.h
+++ b/src/unix/kerberos_gss.h
@@ -25,6 +25,8 @@ extern "C" {
 
 #include <string>
 
+namespace node_kerberos {
+
 inline const char* krb5_get_err_text(const krb5_context&, krb5_error_code code) {
     return error_message(code);
 }
@@ -101,5 +103,7 @@ gss_result authenticate_user_krb5pwd(const char* user,
                                      const char* pswd,
                                      const char* service,
                                      const char* default_realm);
+
+}
 
 #endif

--- a/src/unix/kerberos_gss.h
+++ b/src/unix/kerberos_gss.h
@@ -43,32 +43,39 @@ typedef struct {
     std::string data;
 } gss_result;
 
-typedef struct {
+struct gss_client_state {
     gss_ctx_id_t context;
     gss_name_t server_name;
     gss_OID mech_oid;
     long int gss_flags;
     gss_cred_id_t client_creds;
-    char* username;
-    char* response;
-    int responseConf;
-    bool context_complete;
-} gss_client_state;
+    char* username = nullptr;
+    char* response = nullptr;
+    int responseConf = 0;
+    bool context_complete = false;
 
-typedef struct {
+    gss_client_state() {}
+    gss_client_state(const gss_client_state&) = delete;
+    gss_client_state& operator=(const gss_client_state&) = delete;
+    ~gss_client_state();
+};
+
+struct gss_server_state {
     gss_ctx_id_t context;
     gss_name_t server_name;
     gss_name_t client_name;
     gss_cred_id_t server_creds;
     gss_cred_id_t client_creds;
-    char* username;
-    char* targetname;
-    char* response;
-    bool context_complete;
-} gss_server_state;
+    char* username = nullptr;
+    char* targetname = nullptr;
+    char* response = nullptr;
+    bool context_complete = false;
 
-gss_client_state* gss_client_state_new();
-gss_server_state* gss_server_state_new();
+    gss_server_state() {}
+    gss_server_state(const gss_server_state&) = delete;
+    gss_server_state& operator=(const gss_server_state&) = delete;
+    ~gss_server_state();
+};
 
 gss_result server_principal_details(const char* service, const char* hostname);
 
@@ -79,7 +86,6 @@ gss_result authenticate_gss_client_init(const char* service,
                                         gss_OID mech_oid,
                                         gss_client_state* state);
 
-int authenticate_gss_client_clean(gss_client_state* state);
 gss_result authenticate_gss_client_step(gss_client_state* state,
                                         const char* challenge,
                                         struct gss_channel_bindings_struct* channel_bindings);
@@ -89,7 +95,6 @@ gss_result authenticate_gss_client_wrap(gss_client_state* state,
                                         const char* user,
                                         int protect);
 gss_result authenticate_gss_server_init(const char* service, gss_server_state* state);
-int authenticate_gss_server_clean(gss_server_state* state);
 gss_result authenticate_gss_server_step(gss_server_state* state, const char* challenge);
 
 gss_result authenticate_user_krb5pwd(const char* user,

--- a/src/unix/kerberos_unix.cc
+++ b/src/unix/kerberos_unix.cc
@@ -156,7 +156,7 @@ void InitializeClient(const CallbackInfo& info) {
             }
 
             worker->Call(std::initializer_list<napi_value>
-                { env.Null(), KerberosClient::NewInstance(env, client_state) });
+                { env.Null(), KerberosClient::NewInstance(env, std::move(client_state)) });
         });
     });
 }
@@ -179,7 +179,7 @@ void InitializeServer(const CallbackInfo& info) {
             }
 
             worker->Call(std::initializer_list<napi_value>
-                { env.Null(), KerberosServer::NewInstance(env, server_state) });
+                { env.Null(), KerberosServer::NewInstance(env, std::move(server_state)) });
         });
     });
 }

--- a/src/unix/kerberos_unix.cc
+++ b/src/unix/kerberos_unix.cc
@@ -3,6 +3,10 @@
 #include "../kerberos.h"
 #include "../kerberos_worker.h"
 
+namespace node_kerberos {
+
+using namespace Napi;
+
 #define GSS_MECH_OID_KRB5 9
 #define GSS_MECH_OID_SPNEGO 6
 
@@ -13,63 +17,63 @@ static char spnego_mech_oid_bytes[] = "\x2b\x06\x01\x05\x05\x02";
 gss_OID_desc spnego_mech_oid = {6, &spnego_mech_oid_bytes};
 
 /// KerberosClient
-NAN_METHOD(KerberosClient::Step) {
-    auto state = Nan::ObjectWrap::Unwrap<KerberosClient>(info.This())->state();
-    std::string challenge(*Nan::Utf8String(info[0]));
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
+void KerberosClient::Step(const CallbackInfo& info) {
+    auto state = this->state();
+    std::string challenge = info[0].ToString();
+    Function callback = info[1].As<Function>();
 
     KerberosWorker::Run(callback, "kerberos:ClientStep", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         gss_result result =
             authenticate_gss_client_step(state.get(), challenge.c_str(), NULL);
 
         return onFinished([=](KerberosWorker* worker) {
-            Nan::HandleScope scope;
+            Napi::Env env = worker->Env();
             if (result.code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
-                worker->Call(2, argv);
+                worker->Call(std::initializer_list<napi_value>
+                    { Error::New(env, result.message).Value(), env.Null() });
                 return;
             }
 
-            v8::Local<v8::Value> response = Nan::Null();
-            if (state->response != NULL) {
-                response = Nan::New(state->response).ToLocalChecked();
+            Napi::Value response = env.Null();
+            if (state->response != nullptr) {
+                response = String::New(env, state->response);
             }
 
-            v8::Local<v8::Value> argv[] = {Nan::Null(), response};
-            worker->Call(2, argv);
+            worker->Call(std::initializer_list<napi_value>
+                { env.Null(), response });
         });
     });
 }
 
-NAN_METHOD(KerberosClient::UnwrapData) {
-    auto state = Nan::ObjectWrap::Unwrap<KerberosClient>(info.This())->state();
-    std::string challenge(*Nan::Utf8String(info[0]));
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
+void KerberosClient::UnwrapData(const CallbackInfo& info) {
+    auto state = this->state();
+    std::string challenge = info[0].ToString();
+    Function callback = info[1].As<Function>();
 
     KerberosWorker::Run(callback, "kerberos:ClientUnwrap", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         gss_result result =
             authenticate_gss_client_unwrap(state.get(), challenge.c_str());
 
         return onFinished([=](KerberosWorker* worker) {
-            Nan::HandleScope scope;
+            Napi::Env env = worker->Env();
             if (result.code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
-                worker->Call(2, argv);
+                worker->Call(std::initializer_list<napi_value>
+                    { Error::New(env, result.message).Value(), env.Null() });
                 return;
             }
 
-            v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::New(state->response).ToLocalChecked()};
-            worker->Call(2, argv);
+            worker->Call(std::initializer_list<napi_value>
+                { env.Null(), String::New(env, state->response) });
         });
     });
 }
 
-NAN_METHOD(KerberosClient::WrapData) {
-    auto state = Nan::ObjectWrap::Unwrap<KerberosClient>(info.This())->state();
-    std::string challenge(*Nan::Utf8String(info[0]));
-    v8::Local<v8::Object> options = Nan::To<v8::Object>(info[1]).ToLocalChecked();
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[2]).ToLocalChecked());
-    std::string user = StringOptionValue(options, "user");
+void KerberosClient::WrapData(const CallbackInfo& info) {
+    auto state = this->state();
+    std::string challenge = info[0].ToString();
+    Object options = info[1].ToObject();
+    Function callback = info[2].As<Function>();
+    std::string user = ToStringWithNonStringAsEmpty(options["user"]);
 
     int protect = 0; // NOTE: this should be an option
 
@@ -78,58 +82,59 @@ NAN_METHOD(KerberosClient::WrapData) {
             state.get(), challenge.c_str(), user.c_str(), protect);
 
         return onFinished([=](KerberosWorker* worker) {
-            Nan::HandleScope scope;
+            Napi::Env env = worker->Env();
             if (result.code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
-                worker->Call(2, argv);
+                worker->Call(std::initializer_list<napi_value>
+                    { Error::New(env, result.message).Value(), env.Null() });
                 return;
             }
 
-            v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::New(state->response).ToLocalChecked()};
-            worker->Call(2, argv);
+            worker->Call(std::initializer_list<napi_value>
+                { env.Null(), String::New(env, state->response) });
         });
     });
 }
 
 /// KerberosServer
-NAN_METHOD(KerberosServer::Step) {
-    auto state = Nan::ObjectWrap::Unwrap<KerberosServer>(info.This())->state();
-    std::string challenge(*Nan::Utf8String(info[0]));
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
+void KerberosServer::Step(const CallbackInfo& info) {
+    auto state = this->state();
+    std::string challenge = info[0].ToString();
+    Function callback = info[1].As<Function>();
 
     KerberosWorker::Run(callback, "kerberos:ServerStep", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         gss_result result =
             authenticate_gss_server_step(state.get(), challenge.c_str());
 
         return onFinished([=](KerberosWorker* worker) {
-            Nan::HandleScope scope;
+            Napi::Env env = worker->Env();
             if (result.code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
-                worker->Call(2, argv);
+                worker->Call(std::initializer_list<napi_value>
+                    { Error::New(env, result.message).Value(), env.Null() });
                 return;
             }
 
-            v8::Local<v8::Value> response = Nan::Null();
-            if (state->response != NULL) {
-                response = Nan::New(state->response).ToLocalChecked();
+            Napi::Value response = env.Null();
+            if (state->response != nullptr) {
+                response = String::New(env, state->response);
             }
 
-            v8::Local<v8::Value> argv[] = {Nan::Null(), response};
-            worker->Call(2, argv);
+            worker->Call(std::initializer_list<napi_value>
+                { env.Null(), response });
         });
     });
 }
 
 /// Global Methods
-NAN_METHOD(InitializeClient) {
-    std::string service(*Nan::Utf8String(info[0]));
-    v8::Local<v8::Object> options = Nan::To<v8::Object>(info[1]).ToLocalChecked();
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[2]).ToLocalChecked());
+void InitializeClient(const CallbackInfo& info) {
+    std::string service = info[0].ToString();
+    Object options = info[1].ToObject();
+    Function callback = info[2].As<Function>();
 
-    std::string principal = StringOptionValue(options, "principal");
-    uint32_t gss_flags =
-        UInt32OptionValue(options, "gssFlags", GSS_C_MUTUAL_FLAG | GSS_C_SEQUENCE_FLAG);
-    uint32_t mech_oid_int = UInt32OptionValue(options, "mechOID", 0);
+    std::string principal = ToStringWithNonStringAsEmpty(options["principal"]);
+    Value flags_v = options["flags"];
+    uint32_t gss_flags = flags_v.IsNumber() ? flags_v.As<Number>().Uint32Value() : GSS_C_MUTUAL_FLAG|GSS_C_SEQUENCE_FLAG;
+    Value mech_oid_v = options["mechOID"];
+    uint32_t mech_oid_int = mech_oid_v.IsNumber() ? mech_oid_v.As<Number>().Uint32Value() : 0;
     gss_OID mech_oid = GSS_C_NO_OID;
     if (mech_oid_int == GSS_MECH_OID_KRB5) {
         mech_oid = &krb5_mech_oid;
@@ -143,22 +148,22 @@ NAN_METHOD(InitializeClient) {
             service.c_str(), principal.c_str(), gss_flags, NULL, mech_oid, client_state.get());
 
         return onFinished([=](KerberosWorker* worker) {
-            Nan::HandleScope scope;
+            Napi::Env env = worker->Env();
             if (result.code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
-                worker->Call(2, argv);
+                worker->Call(std::initializer_list<napi_value>
+                    { Error::New(env, result.message).Value(), env.Null() });
                 return;
             }
 
-            v8::Local<v8::Value> argv[] = {Nan::Null(), KerberosClient::NewInstance(client_state)};
-            worker->Call(2, argv);
+            worker->Call(std::initializer_list<napi_value>
+                { env.Null(), KerberosClient::NewInstance(env, client_state) });
         });
     });
 }
 
-NAN_METHOD(InitializeServer) {
-    std::string service(*Nan::Utf8String(info[0]));
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
+void InitializeServer(const CallbackInfo& info) {
+    std::string service = info[0].ToString();
+    Function callback = info[1].As<Function>();
 
     KerberosWorker::Run(callback, "kerberos:InitializeServer", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         auto server_state = std::make_shared<gss_server_state>();
@@ -166,54 +171,54 @@ NAN_METHOD(InitializeServer) {
             authenticate_gss_server_init(service.c_str(), server_state.get());
 
         return onFinished([=](KerberosWorker* worker) {
-            Nan::HandleScope scope;
+            Napi::Env env = worker->Env();
             if (result.code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
-                worker->Call(2, argv);
+                worker->Call(std::initializer_list<napi_value>
+                    { Error::New(env, result.message).Value(), env.Null() });
                 return;
             }
 
-            v8::Local<v8::Value> argv[] = {Nan::Null(), KerberosServer::NewInstance(server_state)};
-            worker->Call(2, argv);
+            worker->Call(std::initializer_list<napi_value>
+                { env.Null(), KerberosServer::NewInstance(env, server_state) });
         });
     });
 }
 
-NAN_METHOD(PrincipalDetails) {
-    std::string service(*Nan::Utf8String(info[0]));
-    std::string hostname(*Nan::Utf8String(info[1]));
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[2]).ToLocalChecked());
+void PrincipalDetails(const CallbackInfo& info) {
+    std::string service = info[0].ToString();
+    std::string hostname = info[1].ToString();
+    Function callback = info[2].As<Function>();
 
     KerberosWorker::Run(callback, "kerberos:PrincipalDetails", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         gss_result result =
             server_principal_details(service.c_str(), hostname.c_str());
 
         return onFinished([=](KerberosWorker* worker) {
-            Nan::HandleScope scope;
+            Napi::Env env = worker->Env();
             if (result.code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
-                worker->Call(2, argv);
+                worker->Call(std::initializer_list<napi_value>
+                    { Error::New(env, result.message).Value(), env.Null() });
                 return;
             }
 
-            v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::New(result.data.c_str()).ToLocalChecked()};
-            worker->Call(2, argv);
+            worker->Call(std::initializer_list<napi_value>
+                { env.Null(), String::New(env, result.data) });
         });
     });
 }
 
-NAN_METHOD(CheckPassword) {
-    std::string username(*Nan::Utf8String(info[0]));
-    std::string password(*Nan::Utf8String(info[1]));
-    std::string service(*Nan::Utf8String(info[2]));
+void CheckPassword(const CallbackInfo& info) {
+    std::string username = info[0].ToString();
+    std::string password = info[1].ToString();
+    std::string service = info[2].ToString();
 
     std::string defaultRealm;
-    Nan::Callback* callback;
-    if (info[3]->IsFunction()) {
-        callback = new Nan::Callback(Nan::To<v8::Function>(info[3]).ToLocalChecked());
+    Function callback;
+    if (info[3].IsFunction()) {
+        callback = info[3].As<Function>();
     } else {
-        defaultRealm = *Nan::Utf8String(info[3]);
-        callback = new Nan::Callback(Nan::To<v8::Function>(info[4]).ToLocalChecked());
+        defaultRealm = info[3].ToString();
+        callback = info[4].As<Function>();
     }
 
     KerberosWorker::Run(callback, "kerberos:CheckPassword", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
@@ -221,14 +226,16 @@ NAN_METHOD(CheckPassword) {
             username.c_str(), password.c_str(), service.c_str(), defaultRealm.c_str());
 
         return onFinished([=](KerberosWorker* worker) {
-            Nan::HandleScope scope;
+            Napi::Env env = worker->Env();
             if (result.code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
-                worker->Call(2, argv);
+                worker->Call(std::initializer_list<napi_value>
+                    { Error::New(env, result.message).Value(), env.Null() });
             } else {
-                v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::Null()};
-                worker->Call(2, argv);
+                worker->Call(std::initializer_list<napi_value>
+                    { env.Null(), env.Null() });
             }
         });
     });
+}
+
 }

--- a/src/win32/kerberos_sspi.cc
+++ b/src/win32/kerberos_sspi.cc
@@ -2,6 +2,8 @@
 #include <cstdio>
 #include "kerberos_sspi.h"
 
+namespace node_kerberos {
+
 static sspi_result sspi_success_result(INT ret);
 static sspi_result sspi_error_result(DWORD errCode, const SEC_CHAR* msg);
 static sspi_result sspi_error_result_with_message(const char* message);
@@ -14,11 +16,11 @@ sspi_client_state::~sspi_client_state() {
         DeleteSecurityContext(&ctx);
     }
     if (haveCred) {
-        FreeCredentialsHandle(&state->cred);
+        FreeCredentialsHandle(&cred);
     }
-    free(state->spn);
-    free(state->response);
-    free(state->username);
+    free(spn);
+    free(response);
+    free(username);
 }
 
 sspi_result
@@ -533,4 +535,6 @@ wide_to_utf8(WCHAR* value) {
     }
 
     return NULL;
+}
+
 }

--- a/src/win32/kerberos_sspi.cc
+++ b/src/win32/kerberos_sspi.cc
@@ -9,37 +9,16 @@ static SEC_CHAR* base64_encode(const SEC_CHAR* value, DWORD vlen);
 static SEC_CHAR* base64_decode(const SEC_CHAR* value, DWORD* rlen);
 static CHAR* wide_to_utf8(WCHAR* value);
 
-sspi_client_state* sspi_client_state_new() {
-    sspi_client_state* state = (sspi_client_state*)malloc(sizeof(sspi_client_state));
-    state->username = NULL;
-    state->response = NULL;
-    state->responseConf = 0;
-    state->context_complete = FALSE;
-    return state;
-}
-
-VOID
-auth_sspi_client_clean(sspi_client_state* state) {
-    if (state->haveCtx) {
-        DeleteSecurityContext(&state->ctx);
-        state->haveCtx = 0;
+sspi_client_state::~sspi_client_state() {
+    if (haveCtx) {
+        DeleteSecurityContext(&ctx);
     }
-    if (state->haveCred) {
+    if (haveCred) {
         FreeCredentialsHandle(&state->cred);
-        state->haveCred = 0;
     }
-    if (state->spn != NULL) {
-        free(state->spn);
-        state->spn = NULL;
-    }
-    if (state->response != NULL) {
-        free(state->response);
-        state->response = NULL;
-    }
-    if (state->username != NULL) {
-        free(state->username);
-        state->username = NULL;
-    }
+    free(state->spn);
+    free(state->response);
+    free(state->username);
 }
 
 sspi_result

--- a/src/win32/kerberos_sspi.h
+++ b/src/win32/kerberos_sspi.h
@@ -33,27 +33,33 @@ typedef struct {
     std::string data;
 } sspi_result;
 
-typedef struct {
+struct sspi_client_state {
     CredHandle cred;
     CtxtHandle ctx;
-    WCHAR* spn;
-    SEC_CHAR* response;
-    SEC_CHAR* username;
+    WCHAR* spn = nullptr;
+    SEC_CHAR* response = nullptr;
+    SEC_CHAR* username = nullptr;
     ULONG flags;
-    UCHAR haveCred;
-    UCHAR haveCtx;
+    UCHAR haveCred = 0;
+    UCHAR haveCtx = 0;
     ULONG qop;
 
-    INT responseConf;
-    BOOL context_complete;
-} sspi_client_state;
+    INT responseConf = 0;
+    BOOL context_complete = FALSE;
 
-typedef struct {
-    WCHAR* username;
-    WCHAR* response;
-    BOOL context_complete;
+    sspi_client_state() {}
+    sspi_client_state(const sspi_client_state&) = delete;
+    sspi_client_state& operator=(const sspi_client_state&) = delete;
+    ~sspi_client_state();
+};
+
+struct sspi_server_state {
+    // This is unused currently
+    WCHAR* username = nullptr;
+    WCHAR* response = nullptr;
+    BOOL context_complete = FALSE;
     char* targetname;
-} sspi_server_state;
+};
 
 sspi_client_state* sspi_client_state_new();
 VOID auth_sspi_client_clean(sspi_client_state* state);

--- a/src/win32/kerberos_sspi.h
+++ b/src/win32/kerberos_sspi.h
@@ -23,6 +23,8 @@
 #include <sspi.h>
 #include <string>
 
+namespace node_kerberos {
+
 #define AUTH_GSS_ERROR -1
 #define AUTH_GSS_COMPLETE 1
 #define AUTH_GSS_CONTINUE 0
@@ -58,7 +60,7 @@ struct sspi_server_state {
     WCHAR* username = nullptr;
     WCHAR* response = nullptr;
     BOOL context_complete = FALSE;
-    char* targetname;
+    char* targetname = nullptr;
 };
 
 sspi_client_state* sspi_client_state_new();
@@ -77,5 +79,7 @@ sspi_result auth_sspi_client_init(WCHAR* service,
 sspi_result auth_sspi_client_step(sspi_client_state* state, SEC_CHAR* challenge, SecPkgContext_Bindings* sec_pkg_context_bindings);
 sspi_result auth_sspi_client_unwrap(sspi_client_state* state, SEC_CHAR* challenge);
 sspi_result auth_sspi_client_wrap(sspi_client_state* state, SEC_CHAR* data, SEC_CHAR* user, ULONG ulen, INT protect);
+
+}
 
 #endif

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -144,7 +144,7 @@ void InitializeClient(const CallbackInfo& info) {
             }
 
             worker->Call(std::initializer_list<napi_value>
-                { env.Null(), KerberosClient::NewInstance(env, client_state) });
+                { env.Null(), KerberosClient::NewInstance(env, std::move(client_state)) });
         });
     });
 }

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -3,6 +3,20 @@
 #include "../kerberos.h"
 #include "../kerberos_worker.h"
 
+namespace node_kerberos {
+
+using namespace Napi;
+
+inline std::wstring ToWStringWithNonStringAsEmpty(Value value) {
+    static_assert(sizeof(std::wstring::value_type) == sizeof(std::u16string::value_type),
+        "wstring and u16string have the same value type on Windows");
+    if (!value.IsString()) {
+        return std::wstring();
+    }
+    std::u16string u16 = value.As<String>();
+    return std::wstring(u16.begin(), u16.end());
+}
+
 #define GSS_MECH_OID_KRB5 9
 #define GSS_MECH_OID_SPNEGO 6
 #define GSS_MECH_OID_KRB5_STR L"Kerberos"
@@ -12,89 +26,64 @@
 #define GSS_C_REPLAY_FLAG 4
 #define GSS_C_SEQUENCE_FLAG 8
 
-const std::wstring to_wstring(const char *bytes) {
-    DWORD sizeOfStr = MultiByteToWideChar(CP_UTF8, 0, bytes, -1, NULL, 0);
-    assert(sizeOfStr > 0);
-    std::wstring arg(sizeOfStr, '\0');
-    DWORD result = MultiByteToWideChar(CP_UTF8, 0, bytes, -1, &arg[0], sizeOfStr);
-    assert(result > 0);
-    arg.resize(result - 1);
-    return arg;
-}
-
-NAN_INLINE std::wstring WStringOptionValue(v8::Local<v8::Object> options, const char* _key) {
-    Nan::HandleScope scope;
-    v8::Local<v8::String> key = Nan::New(_key).ToLocalChecked();
-    if (options.IsEmpty() || !Nan::Has(options, key).FromMaybe(false)) {
-      return std::wstring();
-    }
-
-    v8::Local<v8::Value> value = Nan::Get(options, key).ToLocalChecked();
-    if (!value->IsString()) {
-      return std::wstring();
-    }
-
-    return to_wstring(*(Nan::Utf8String(value)));
-}
-
 /// KerberosClient
-NAN_METHOD(KerberosClient::Step) {
-    auto state = Nan::ObjectWrap::Unwrap<KerberosClient>(info.This())->state();
-    std::string challenge(*Nan::Utf8String(info[0]));
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
+void KerberosClient::Step(const CallbackInfo& info) {
+    auto state = this->state();
+    std::string challenge = info[0].ToString();
+    Function callback = info[1].As<Function>();
 
     KerberosWorker::Run(callback, "kerberos:ClientStep", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         sspi_result result =
             auth_sspi_client_step(state.get(), (SEC_CHAR*)challenge.c_str(), NULL);
 
         return onFinished([=](KerberosWorker* worker) {
-            Nan::HandleScope scope;
+            Napi::Env env = worker->Env();
             if (result.code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
-                worker->Call(2, argv);
+                worker->Call(std::initializer_list<napi_value>
+                    { Error::New(env, result.message).Value(), env.Null() });
                 return;
             }
 
-            v8::Local<v8::Value> response = Nan::Null();
-            if (state->response != NULL) {
-                response = Nan::New(state->response).ToLocalChecked();
+            Napi::Value response = env.Null();
+            if (state->response != nullptr) {
+                response = String::New(env, state->response);
             }
 
-            v8::Local<v8::Value> argv[] = {Nan::Null(), response};
-            worker->Call(2, argv);
+            worker->Call(std::initializer_list<napi_value>
+                { env.Null(), response });
         });
     });
 }
 
-NAN_METHOD(KerberosClient::UnwrapData) {
-    auto state = Nan::ObjectWrap::Unwrap<KerberosClient>(info.This())->state();
-    std::string challenge(*Nan::Utf8String(info[0]));
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[1]).ToLocalChecked());
+void KerberosClient::UnwrapData(const CallbackInfo& info) {
+    auto state = this->state();
+    std::string challenge = info[0].ToString();
+    Function callback = info[1].As<Function>();
 
     KerberosWorker::Run(callback, "kerberos:ClientUnwrap", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         sspi_result result =
             auth_sspi_client_unwrap(state.get(), (SEC_CHAR*)challenge.c_str());
 
         return onFinished([=](KerberosWorker* worker) {
-            Nan::HandleScope scope;
+            Napi::Env env = worker->Env();
             if (result.code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
-                worker->Call(2, argv);
+                worker->Call(std::initializer_list<napi_value>
+                    { Error::New(env, result.message).Value(), env.Null() });
                 return;
             }
 
-            v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::New(state->response).ToLocalChecked()};
-            worker->Call(2, argv);
+            worker->Call(std::initializer_list<napi_value>
+                { env.Null(), String::New(env, state->response) });
         });
     });
 }
 
-NAN_METHOD(KerberosClient::WrapData) {
-    auto state = Nan::ObjectWrap::Unwrap<KerberosClient>(info.This())->state();
-    std::string challenge(*Nan::Utf8String(info[0]));
-    v8::Local<v8::Object> options = Nan::To<v8::Object>(info[1]).ToLocalChecked();
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[2]).ToLocalChecked());
-    std::string user = StringOptionValue(options, "user");
+void KerberosClient::WrapData(const CallbackInfo& info) {
+    auto state = this->state();
+    std::string challenge = info[0].ToString();
+    Object options = info[1].ToObject();
+    Function callback = info[2].As<Function>();
+    std::string user = ToStringWithNonStringAsEmpty(options["user"]);
     int protect = 0; // NOTE: this should be an option
 
     KerberosWorker::Run(callback, "kerberos:ClientWrap", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
@@ -102,36 +91,38 @@ NAN_METHOD(KerberosClient::WrapData) {
             state.get(), (SEC_CHAR*)challenge.c_str(), (SEC_CHAR*)user.c_str(), user.length(), protect);
 
         return onFinished([=](KerberosWorker* worker) {
-            Nan::HandleScope scope;
+            Napi::Env env = worker->Env();
 
             if (result.code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
-                worker->Call(2, argv);
+                worker->Call(std::initializer_list<napi_value>
+                    { Error::New(env, result.message).Value(), env.Null() });
                 return;
             }
 
-            v8::Local<v8::Value> argv[] = {Nan::Null(), Nan::New(state->response).ToLocalChecked()};
-            worker->Call(2, argv);
+            worker->Call(std::initializer_list<napi_value>
+                { env.Null(), String::New(env, state->response) });
         });
     });
 }
 
 /// KerberosServer
-NAN_METHOD(KerberosServer::Step) {
-    Nan::ThrowError("`KerberosServer::Step` is not implemented yet for windows");
+void KerberosServer::Step(const CallbackInfo& info) {
+    throw Error::New(info.Env(), "`KerberosServer::Step` is not implemented yet for windows");
 }
 
 /// Global Methods
-NAN_METHOD(InitializeClient) {
-    std::wstring service = to_wstring(*(Nan::Utf8String(info[0])));
-    v8::Local<v8::Object> options = Nan::To<v8::Object>(info[1]).ToLocalChecked();
-    Nan::Callback* callback = new Nan::Callback(Nan::To<v8::Function>(info[2]).ToLocalChecked());
+void InitializeClient(const CallbackInfo& info) {
+    std::wstring service = ToWStringWithNonStringAsEmpty(info[0]);
+    Object options = info[1].ToObject();
+    Function callback = info[2].As<Function>();
 
-    std::wstring user = WStringOptionValue(options, "user");
-    std::wstring domain = WStringOptionValue(options, "domain");
-    std::wstring password = WStringOptionValue(options, "password");
-    ULONG gss_flags = (ULONG)UInt32OptionValue(options, "flags", GSS_C_MUTUAL_FLAG|GSS_C_SEQUENCE_FLAG);
-    uint32_t mech_oid_int = UInt32OptionValue(options, "mechOID", 0);
+    std::wstring user = ToWStringWithNonStringAsEmpty(options["user"]);
+    std::wstring domain = ToWStringWithNonStringAsEmpty(options["domain"]);
+    std::wstring password = ToWStringWithNonStringAsEmpty(options["password"]);
+    Value flags_v = options["flags"];
+    ULONG gss_flags = flags_v.IsNumber() ? flags_v.As<Number>().Uint32Value() : GSS_C_MUTUAL_FLAG|GSS_C_SEQUENCE_FLAG;
+    Value mech_oid_v = options["mechOID"];
+    uint32_t mech_oid_int = mech_oid_v.IsNumber() ? mech_oid_v.As<Number>().Uint32Value() : 0;
     std::wstring mech_oid = GSS_MECH_OID_KRB5_STR;
     if (mech_oid_int == GSS_MECH_OID_SPNEGO) {
         mech_oid = GSS_MECH_OID_SPNEGO_STR;
@@ -145,27 +136,29 @@ NAN_METHOD(InitializeClient) {
             (WCHAR*)mech_oid.c_str(), client_state.get());
 
         return onFinished([=](KerberosWorker* worker) {
-            Nan::HandleScope scope;
+            Napi::Env env = worker->Env();
             if (result.code == AUTH_GSS_ERROR) {
-                v8::Local<v8::Value> argv[] = {Nan::Error(result.message.c_str()), Nan::Null()};
-                worker->Call(2, argv);
+                worker->Call(std::initializer_list<napi_value>
+                    { Error::New(env, result.message).Value(), env.Null() });
                 return;
             }
 
-            v8::Local<v8::Value> argv[] = {Nan::Null(), KerberosClient::NewInstance(client_state)};
-            worker->Call(2, argv);
+            worker->Call(std::initializer_list<napi_value>
+                { env.Null(), KerberosClient::NewInstance(env, client_state) });
         });
     });
 }
 
-NAN_METHOD(InitializeServer) {
-    Nan::ThrowError("`initializeServer` is not implemented yet for windows");
+void InitializeServer(const CallbackInfo& info) {
+    throw Error::New(info.Env(), "`initializeServer` is not implemented yet for windows");
 }
 
-NAN_METHOD(PrincipalDetails) {
-    Nan::ThrowError("`principalDetails` is not implemented yet for windows");
+void PrincipalDetails(const CallbackInfo& info) {
+    throw Error::New(info.Env(), "`principalDetails` is not implemented yet for windows");
 }
 
-NAN_METHOD(CheckPassword) {
-    Nan::ThrowError("`checkPassword` is not implemented yet for windows");
+void CheckPassword(const CallbackInfo& info) {
+    throw Error::New(info.Env(), "`checkPassword` is not implemented yet for windows");
+}
+
 }


### PR DESCRIPTION
mongosh integration patch: https://spruce.mongodb.com/version/614b2cf5e3c331087eee218b/tasks

##### chore: address TODO for managing state through smart pointers

Address the TODOs asking for the state to be managed through
smart pointers and as a proper class with destructors.

This is helpful for the upcoming Node-API conversion, because
the presence of C++ exceptions in Node-API (and the fact that
Node-API support also comes with multithreading support) makes
it important to use proper C++ RAII style in order to avoid
memory leaks.

##### feat!(NODE-3472): convert to Node-API

