### PR TITLE
test(NODE-3743): bump windows environment

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -127,8 +127,8 @@ buildvariants:
       - run-prebuild
       - run-prebuild-force-publish
   - name: windows-x64
-    display_name: "Windows 2016"
-    run_on: windows-64-vs2017-test
+    display_name: "Windows 2019"
+    run_on: windows-64-vs2019-test
     tasks:
       # - run-tests
       - run-prebuild

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -127,8 +127,8 @@ buildvariants:
       - run-prebuild
       - run-prebuild-force-publish
   - name: windows-x64
-    display_name: "Windows 2019"
-    run_on: windows-64-vs2019-test
+    display_name: "Windows 2017"
+    run_on: windows-64-vs2017-test
     tasks:
       # - run-tests
       - run-prebuild

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -58,4 +58,7 @@ registry=https://registry.npmjs.org
 EOT
 
 # install node dependencies
+if [ "$OS" == "Windows_NT" ]; then
+  npm install --global windows-build-tools
+fi
 npm install --unsafe-perm

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -58,7 +58,4 @@ registry=https://registry.npmjs.org
 EOT
 
 # install node dependencies
-if [ "$OS" == "Windows_NT" ]; then
-  npm install --global windows-build-tools
-fi
 npm install --unsafe-perm


### PR DESCRIPTION
### Description

Bumps evergreen windows environment to vs2019.

#### What is changing?

Bumps evergreen windows environment to vs2019 to attempt to fix build errors.

#### What is the motivation for this change?

NODE-3743

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the relevant portions of the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
