### PR TITLE
fix(NODE-3982): only pass username to SSPI if password is set

### DIFF
--- a/src/win32/kerberos_sspi.cc
+++ b/src/win32/kerberos_sspi.cc
@@ -79,7 +79,7 @@ auth_sspi_client_init(WCHAR* service,
                                        /* LogonID (We don't use this) */
                                        NULL,
                                        /* AuthData */
-                                       *user ? &authIdentity : NULL,
+                                       authIdentity.Password ? &authIdentity : NULL,
                                        /* Always NULL */
                                        NULL,
                                        /* Always NULL */


### PR DESCRIPTION
### Description

#### What is changing?

On Windows, a password is required in order for the input credentials to be forwarded to SSPI.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

See https://jira.mongodb.org/browse/DRIVERS-2180 – Pending confirmation from TS, this resolves connectivity issues when only the username is passed to the MongoDB driver when connecting using kerberos. (mongosh test build with this patch available at https://s3.amazonaws.com/mciuploads/mongosh/5afb80349eab42e026c5c8219cf378c7933b0d66/mongosh-0.0.0-dev.0-win32-x64.zip)


### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the relevant portions of the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
