### PR TITLE
test(NODE-4669): use node 18 in container

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -134,18 +134,21 @@ buildvariants:
     display_name: 'macOS 10.14'
     run_on: macos-1014
     tasks:
+      - run-tests-ubuntu
       - run-prebuild
       - run-prebuild-force-publish
   - name: macos-m1
     display_name: MacOS M1
     run_on: macos-1100-arm64
     tasks:
+      - run-tests-ubuntu
       - run-prebuild
       - run-prebuild-force-publish
   - name: windows-x64
     display_name: 'Windows 2016'
     run_on: windows-64-vs2017-test
     tasks:
+      - run-tests-ubuntu
       - run-prebuild
       - run-prebuild-force-publish
   - name: suse12-s390x
@@ -156,6 +159,7 @@ buildvariants:
       packager_distro: suse12
       packager_arch: s390x
     tasks:
+      - run-tests-ubuntu
       - run-prebuild
       - run-prebuild-force-publish
   - name: ubuntu2004-64
@@ -177,5 +181,6 @@ buildvariants:
       packager_distro: ubuntu2004
       packager_arch: arm64
     tasks:
+      - run-tests-ubuntu
       - run-prebuild
       - run-prebuild-force-publish

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -134,21 +134,18 @@ buildvariants:
     display_name: 'macOS 10.14'
     run_on: macos-1014
     tasks:
-      - run-tests-ubuntu
       - run-prebuild
       - run-prebuild-force-publish
   - name: macos-m1
     display_name: MacOS M1
     run_on: macos-1100-arm64
     tasks:
-      - run-tests-ubuntu
       - run-prebuild
       - run-prebuild-force-publish
   - name: windows-x64
     display_name: 'Windows 2016'
     run_on: windows-64-vs2017-test
     tasks:
-      - run-tests-ubuntu
       - run-prebuild
       - run-prebuild-force-publish
   - name: suse12-s390x
@@ -159,7 +156,6 @@ buildvariants:
       packager_distro: suse12
       packager_arch: s390x
     tasks:
-      - run-tests-ubuntu
       - run-prebuild
       - run-prebuild-force-publish
   - name: ubuntu2004-64

--- a/.evergreen/run-tests-ubuntu.sh
+++ b/.evergreen/run-tests-ubuntu.sh
@@ -126,10 +126,10 @@ fi
 source "${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
 
 set -o xtrace
-echo "Run: nvm install 14"
-nvm install 14
-echo "Run: nvm use 14"
-nvm use 14
+echo "Run: nvm install 18"
+nvm install 18
+echo "Run: nvm use 18"
+nvm use 18
 set +o xtrace
 
 


### PR DESCRIPTION
### Description

Updates the Ubuntu container that runs the tests to Node 18.

#### What is changing?

- Updates the docker container to use Node 18
- Runs ubuntu tests additionally on ARM.
- Evergreen project config updated to run ubuntu tests on patches.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4669

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
