### PR TITLE
feat(NODE-5505): add compiler warnings and cast lengths

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -15,7 +15,14 @@
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
       'msvs_settings': {
-        'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+        'VCCLCompilerTool': {
+          'ExceptionHandling': 1,
+          'AdditionalOptions': [
+            '/w34244',
+            '/w34267',
+            '/ZH:SHA_256'
+          ]
+        },
       },
       'conditions': [
         ['OS=="mac"', {

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -79,7 +79,7 @@ void KerberosClient::UnwrapData(const CallbackInfo& info) {
 }
 
 static bool isStringTooLong(const std::string& str) {
-    return str.size() >= ULONG_MAX;
+    return str.length() >= ULONG_MAX;
 }
 
 void KerberosClient::WrapData(const CallbackInfo& info) {
@@ -92,7 +92,6 @@ void KerberosClient::WrapData(const CallbackInfo& info) {
 
     if (isStringTooLong(user)) {
         throw Error::New(info.Env(), "User name is too long");
-        return;
     }
 
     KerberosWorker::Run(callback, "kerberos:ClientWrap", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
@@ -131,15 +130,12 @@ void InitializeClient(const CallbackInfo& info) {
 
     if (isStringTooLong(user)) {
         throw Error::New(info.Env(), "User name is too long");
-        return;
     }
     if (isStringTooLong(domain)) {
         throw Error::New(info.Env(), "Domain is too long");
-        return;
     }
     if (isStringTooLong(password)) {
         throw Error::New(info.Env(), "Password is too long");
-        return;
     }
 
     Value flags_v = options["flags"];

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -88,7 +88,7 @@ void KerberosClient::WrapData(const CallbackInfo& info) {
 
     KerberosWorker::Run(callback, "kerberos:ClientWrap", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         sspi_result result = auth_sspi_client_wrap(
-            state.get(), (SEC_CHAR*)challenge.c_str(), (SEC_CHAR*)user.c_str(), user.length(), protect);
+            state.get(), (SEC_CHAR*)challenge.c_str(), (SEC_CHAR*)user.c_str(), (ULONG)user.length(), protect);
 
         return onFinished([=](KerberosWorker* worker) {
             Napi::Env env = worker->Env();
@@ -131,8 +131,8 @@ void InitializeClient(const CallbackInfo& info) {
     KerberosWorker::Run(callback, "kerberos:InitializeClient", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         auto client_state = std::make_shared<sspi_client_state>();
         sspi_result result = auth_sspi_client_init(
-            (WCHAR*)service.c_str(), gss_flags, (WCHAR*)user.c_str(), user.length(),
-            (WCHAR*)domain.c_str(), domain.length(), (WCHAR*)password.c_str(), password.length(),
+            (WCHAR*)service.c_str(), gss_flags, (WCHAR*)user.c_str(), (ULONG)user.length(),
+            (WCHAR*)domain.c_str(), (ULONG)domain.length(), (WCHAR*)password.c_str(), (ULONG)password.length(),
             (WCHAR*)mech_oid.c_str(), client_state.get());
 
         return onFinished([=](KerberosWorker* worker) {

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -82,6 +82,10 @@ static bool isStringTooLong(const std::string& str) {
     return str.length() >= ULONG_MAX;
 }
 
+static bool isWStringTooLong(const std::wstring& str) {
+    return str.length() >= ULONG_MAX;
+}
+
 void KerberosClient::WrapData(const CallbackInfo& info) {
     auto state = this->state();
     std::string challenge = info[0].ToString();
@@ -128,13 +132,13 @@ void InitializeClient(const CallbackInfo& info) {
     std::wstring domain = ToWStringWithNonStringAsEmpty(options["domain"]);
     std::wstring password = ToWStringWithNonStringAsEmpty(options["password"]);
 
-    if (isStringTooLong(user)) {
+    if (isWStringTooLong(user)) {
         throw Error::New(info.Env(), "User name is too long");
     }
-    if (isStringTooLong(domain)) {
+    if (isWStringTooLong(domain)) {
         throw Error::New(info.Env(), "Domain is too long");
     }
-    if (isStringTooLong(password)) {
+    if (isWStringTooLong(password)) {
         throw Error::New(info.Env(), "Password is too long");
     }
 

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -79,7 +79,7 @@ void KerberosClient::UnwrapData(const CallbackInfo& info) {
 }
 
 static bool isStringTooLong(const std::string& str) {
-    return str.length() >= ULONG_MAX;
+    return str.size() >= ULONG_MAX;
 }
 
 void KerberosClient::WrapData(const CallbackInfo& info) {


### PR DESCRIPTION
### Description

Adds some compiler warnings to binding.gyp to resolve downstream [BinSkim](https://github.com/microsoft/binskim) issues.

#### What is changing?

This PR adds some additional options to VCCLCompilerTool in binding.gyp, and fixes some type-casting compilation warnings that showed up as a result.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

VS Code got some BinSkim issues having to do with this library after starting to use it. The issues are:

- Compiler warnings [4244](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244?view=msvc-170) and [4267](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267?view=msvc-170) aren't enabled (this PR handles that, and also adds a config flag to always use SHA-256 for file checksums)
- Compiler control guard (CFG) isn't enabled (not sure if relevant to this project, so I didn't add the flags for now). If this issue is relevant to this project, I can create a tracking bug for it.
- Spectre mitigation isn't enabled (waiting on some upstream PRs to be merged first, since this requires an unreleased node-gyp flag to fix). If this issue is relevant to this project, I can create a tracking bug for it.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
