### PR TITLE
fix(NODE-5600): use ubuntu 18 to build and publish

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -163,23 +163,23 @@ buildvariants:
     tasks:
       - run-prebuild
       - run-prebuild-force-publish
-  - name: ubuntu2004-64
-    display_name: 'Ubuntu 20.04 64-bit'
-    run_on: ubuntu2004-small
+  - name: ubuntu1804-64
+    display_name: 'Ubuntu 18.04 64-bit'
+    run_on: ubuntu1804-test
     expansions:
       has_packages: true
-      packager_distro: ubuntu2004
+      packager_distro: ubuntu1804
       packager_arch: x86_64
     tasks:
       - run-tests-ubuntu
       - run-prebuild
       - run-prebuild-force-publish
   - name: ubuntu1804-arm64
-    display_name: 'Ubuntu 20.04 arm64'
-    run_on: ubuntu2004-arm64-small
+    display_name: 'Ubuntu 18.04 arm64'
+    run_on: ubuntu1804-arm64-build
     expansions:
       has_packages: true
-      packager_distro: ubuntu2004
+      packager_distro: ubuntu1804
       packager_arch: arm64
     tasks:
       - run-tests-ubuntu


### PR DESCRIPTION
### Description

Reverts build variants back to Ubuntu 18 to build and publish with a lower GLIBC version.

#### What is changing?

Updates to the Evergreen config to revert some of https://github.com/mongodb-js/kerberos/commit/abaf8d4e32692a889d53a35b05fcaa4df12c280b

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5600

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
