### PR TITLE
chore(NODE-5599): use rhel for zseries

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -153,12 +153,12 @@ buildvariants:
     tasks:
       - run-prebuild
       - run-prebuild-force-publish
-  - name: suse12-s390x
-    display_name: 'SLES 12 s390x'
-    run_on: suse12-zseries-test
+  - name: rhel8-s390x
+    display_name: 'RHEL 8 s390x'
+    run_on: rhel83-zseries-small
     expansions:
       has_packages: true
-      packager_distro: suse12
+      packager_distro: rhel8
       packager_arch: s390x
     tasks:
       - run-prebuild


### PR DESCRIPTION
### Description

Uses RHEL8 for Zseries builds instead of the quarantined SUSE hosts.

#### What is changing?

Evergreen config changes the hosts to RHEL8.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5599

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
