### PR TITLE
feat(NODE-5746): allow runtime linking against system kerberos library

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -67,6 +67,8 @@ functions:
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           PROJECT: ${project}
+          GYP_DEFINES: ${GYP_DEFINES|}
+          NPM_OPTIONS: ${NPM_OPTIONS|}
         args:
           - run
           - '--interactive'
@@ -76,6 +78,10 @@ functions:
           - /app
           - '--env'
           - PROJECT_DIRECTORY=/app
+          - '--env'
+          - GYP_DEFINES
+          - '--env'
+          - NPM_OPTIONS
           - 'ubuntu:22.04'
           - /bin/bash
           - /app/.evergreen/run-tests-ubuntu.sh
@@ -122,6 +128,12 @@ tasks:
   - name: run-tests-ubuntu
     commands:
       - func: run tests ubuntu
+  - name: run-tests-ubuntu-rtld
+    commands:
+      - func: run tests ubuntu
+        vars:
+          GYP_DEFINES: kerberos_use_rtld=true
+          NPM_OPTIONS: --build-from-source
   - name: run-prebuild
     commands:
       - func: install dependencies
@@ -194,6 +206,7 @@ buildvariants:
       packager_arch: x86_64
     tasks:
       - run-tests-ubuntu
+      - run-tests-ubuntu-rtld
   - name: ubuntu2204-arm64
     display_name: 'Ubuntu 22.04 arm64'
     run_on: ubuntu2204-arm64-small
@@ -203,3 +216,4 @@ buildvariants:
       packager_arch: arm64
     tasks:
       - run-tests-ubuntu
+      - run-tests-ubuntu-rtld

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -105,3 +105,4 @@ echo "npm location: $(which npm)"
 echo "npm version: $(npm -v)"
 
 npm install "${NPM_OPTIONS}"
+ldd build/*/kerberos.node || true

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,9 @@
       'sources': [
         'src/kerberos.cc'
       ],
+      'variables': {
+        'kerberos_use_rtld%': 'false'
+      },
       'xcode_settings': {
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
         'CLANG_CXX_LIBRARY': 'libc++',
@@ -36,11 +39,14 @@
             'src/unix/base64.cc',
             'src/unix/kerberos_gss.cc',
             'src/unix/kerberos_unix.cc'
-          ],
+          ]
+        }],
+        ['(OS=="mac" or OS=="linux") and (kerberos_use_rtld!="true")', {
           'link_settings': {
             'libraries': [
               '-lkrb5',
-              '-lgssapi_krb5'
+              '-lgssapi_krb5',
+              '-lcom_err'
             ]
           },
           'conditions': [
@@ -52,6 +58,14 @@
               }
             }]
           ]
+        }],
+        ['(OS=="mac" or OS=="linux") and (kerberos_use_rtld=="true")', {
+          'defines': ['KERBEROS_USE_RTLD=1'],
+          'link_settings': {
+            'libraries': [
+              '-ldl',
+            ]
+          },
         }],
         ['OS=="win"',  {
           'sources': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -45,8 +45,7 @@
           'link_settings': {
             'libraries': [
               '-lkrb5',
-              '-lgssapi_krb5',
-              '-lcom_err'
+              '-lgssapi_krb5'
             ]
           },
           'conditions': [

--- a/src/kerberos.cc
+++ b/src/kerberos.cc
@@ -171,6 +171,10 @@ void TestMethod(const CallbackInfo& info) {
 }
 
 static Object Init(Env env, Object exports) {
+    std::string libraries_unavailable_error;
+    if (!kerberos_libraries_available(&libraries_unavailable_error)) {
+        throw Error::New(env, libraries_unavailable_error);
+    }
     Function KerberosClientCtor = KerberosClient::Init(env);
     Function KerberosServerCtor = KerberosServer::Init(env);
     exports["KerberosClient"] = KerberosClientCtor;

--- a/src/kerberos.h
+++ b/src/kerberos.h
@@ -13,6 +13,8 @@
 
 namespace node_kerberos {
 
+bool kerberos_libraries_available(std::string* error_out);
+
 class KerberosServer : public Napi::ObjectWrap<KerberosServer> {
    public:
     static Napi::Function Init(Napi::Env env);

--- a/src/unix/kerberos_gss.h
+++ b/src/unix/kerberos_gss.h
@@ -27,9 +27,7 @@ extern "C" {
 
 namespace node_kerberos {
 
-inline const char* krb5_get_err_text(const krb5_context&, krb5_error_code code) {
-    return error_message(code);
-}
+const char* krb5_get_err_text(const krb5_context&, krb5_error_code code);
 
 #define AUTH_GSS_ERROR -1
 #define AUTH_GSS_COMPLETE 1

--- a/src/win32/kerberos_sspi.cc
+++ b/src/win32/kerberos_sspi.cc
@@ -4,6 +4,10 @@
 
 namespace node_kerberos {
 
+bool kerberos_libraries_available(std::string*) {
+    return true;
+}
+
 static sspi_result sspi_success_result(INT ret);
 static sspi_result sspi_error_result(DWORD errCode, const SEC_CHAR* msg);
 static sspi_result sspi_error_result_with_message(const char* message);


### PR DESCRIPTION
E.g. `GYP_DEFINES='kerberos_use_rtld=true' npm i --build-from-source` can be used to enable this flag.

- [x] add a CI job that exercises this build config
- [ ] ~~add a CI job to run tests on RHEL8 that would fail without this~~

### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
