### PR TITLE
feat(NODE-5775): Successful build on illumos and Solaris

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -66,6 +66,19 @@
             ]
           },
         }],
+        ['OS=="solaris"', {
+          'sources': [
+            'src/unix/base64.cc',
+            'src/unix/kerberos_gss.cc',
+            'src/unix/kerberos_unix.cc'
+          ],
+          'link_settings': {
+            'libraries': [
+              '-lkrb5',
+              '-lgss'
+            ]
+          }
+        }],
         ['OS=="win"',  {
           'sources': [
             'src/win32/kerberos_sspi.cc',

--- a/src/kerberos_common.h
+++ b/src/kerberos_common.h
@@ -1,7 +1,7 @@
 #ifndef KERBEROS_COMMON_H
 #define KERBEROS_COMMON_H
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__sun__)
 #include "unix/kerberos_gss.h"
 
 namespace node_kerberos {

--- a/src/unix/kerberos_gss.h
+++ b/src/unix/kerberos_gss.h
@@ -19,8 +19,13 @@
 
 extern "C" {
     #include <gssapi/gssapi.h>
+#ifdef __sun__
+    #include <kerberosv5/krb5.h>
+    #include <kerberosv5/com_err.h>
+#else
     #include <gssapi/gssapi_generic.h>
     #include <gssapi/gssapi_krb5.h>
+#endif
 }
 
 #include <string>
@@ -36,6 +41,10 @@ const char* krb5_get_err_text(const krb5_context&, krb5_error_code code);
 #define GSS_AUTH_P_NONE 1
 #define GSS_AUTH_P_INTEGRITY 2
 #define GSS_AUTH_P_PRIVACY 4
+
+#ifdef __sun__
+#define gss_nt_service_name GSS_C_NT_HOSTBASED_SERVICE
+#endif
 
 typedef struct {
     int code;


### PR DESCRIPTION
### Description
Fixed compilation for Solaris and illumos operating systems.

#### What is changing?
It is now possible to use the library on SunOS-based operating systems. The only changes are in conditional snippets that include specific headers.

##### Is there new documentation needed for these changes?
No. The use of modifications occurs transparently.

#### What is the motivation for this change?

I'm working on creating packages for OpenIndiana and some require this library. Please consider this contribution to open up a range of new packages that can be ported in the continuation of the OpenSolaris spirit.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
