### PR TITLE
fix property name

### DIFF
--- a/src/unix/kerberos_unix.cc
+++ b/src/unix/kerberos_unix.cc
@@ -131,7 +131,7 @@ void InitializeClient(const CallbackInfo& info) {
     Function callback = info[2].As<Function>();
 
     std::string principal = ToStringWithNonStringAsEmpty(options["principal"]);
-    Value flags_v = options["flags"];
+    Value flags_v = options["gssFlags"];
     uint32_t gss_flags = flags_v.IsNumber() ? flags_v.As<Number>().Uint32Value() : GSS_C_MUTUAL_FLAG|GSS_C_SEQUENCE_FLAG;
     Value mech_oid_v = options["mechOID"];
     uint32_t mech_oid_int = mech_oid_v.IsNumber() ? mech_oid_v.As<Number>().Uint32Value() : 0;

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -142,7 +142,7 @@ void InitializeClient(const CallbackInfo& info) {
         throw Error::New(info.Env(), "Password is too long");
     }
 
-    Value flags_v = options["flags"];
+    Value flags_v = options["gssFlags"];
     ULONG gss_flags = flags_v.IsNumber() ? flags_v.As<Number>().Uint32Value() : GSS_C_MUTUAL_FLAG|GSS_C_SEQUENCE_FLAG;
     Value mech_oid_v = options["mechOID"];
     uint32_t mech_oid_int = mech_oid_v.IsNumber() ? mech_oid_v.As<Number>().Uint32Value() : 0;


### PR DESCRIPTION
### Description
I corrected the property name in options to the correct one following the documentation.

#### What is changing?
I made changes to two files: kerberos_unix.cc and kerberos_win32.cc. In these files, I corrected the naming of properties in the options for methods where incorrect naming was used.

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
The motivation behind these changes is to ensure that the flags I specified are passed correctly. I aim to use a version with functional features that align with my requirements.