### PR TITLE
fix(NODE-6108): allow building from source on latest Node.js 20.x

### DIFF
--- a/src/kerberos.h
+++ b/src/kerberos.h
@@ -7,6 +7,7 @@
 #define NAPI_VERSION 6
 // as an experimental feature (that has not been changed since then).
 #define NAPI_EXPERIMENTAL
+#define NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT
 
 #include <napi.h>
 #include "kerberos_common.h"


### PR DESCRIPTION
See https://github.com/nodejs/node/issues/52229 – addons using certain features of the node-addon-api package have been broken by an upstream Node.js change if they were setting `NAPI_EXPERIMENTAL`, which `kerberos` is doing.

### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
