### PR TITLE
chore(NODE-6212): generate sarif report and upload sbom file to s3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,4 +68,4 @@ jobs:
           product_name: node-kerberos
           file: sarif-report.json
           # dry_run:  ${{ needs.release_please.outputs.release_created == '' }}
-          dry_run:  true
+          dry_run:  false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,3 +68,37 @@ jobs:
           product_name: node-kerberos
           file: sarif-report.json
           dry_run:  ${{ needs.release_please.outputs.release_created == '' }}
+
+  upload_sbom_lite:
+    environment: release
+    runs-on: ubuntu-latest
+    needs: [release_please]
+    permissions:
+      # required for all workflows
+      security-events: write
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up drivers-github-tools
+        uses: mongodb-labs/drivers-github-tools/setup@v2
+        with:
+          aws_region_name: us-east-1
+          aws_role_arn: ${{ secrets.aws_role_arn }}
+          aws_secret_id: ${{ secrets.aws_secret_id }}
+
+      - name: Get release version and release package file name
+        id: get_version
+        shell: bash
+        run: |
+          package_version=$(jq --raw-output '.version' package.json)
+          echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
+
+      - name: actions/publish_asset_to_s3
+        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@main
+        with:
+          version: ${{ steps.get_version.outputs.package_version }}
+          product_name: node-mongodb-native
+          file: sbom.json
+          dry_run:  ${{ needs.release_please.outputs.release_created == '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,6 @@ jobs:
         uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@main
         with:
           version: ${{ steps.get_version.outputs.package_version }}
-          product_name: node-mongodb-native
+          product_name: node-kerberos
           file: sbom.json
           dry_run:  ${{ needs.release_please.outputs.release_created == '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,45 @@ jobs:
         run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  generate_sarif_report:
+    environment: release
+    runs-on: ubuntu-latest
+    # needs: [release_please]
+    permissions:
+      # required for all workflows
+      security-events: write
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up drivers-github-tools
+        uses: mongodb-labs/drivers-github-tools/setup@v2
+        with: 
+          aws_region_name: us-east-1
+          aws_role_arn: ${{ secrets.aws_role_arn }}
+          aws_secret_id: ${{ secrets.aws_secret_id }}
+
+      - name: "Generate Sarif Report"
+        # TODO: Use v2 once it has been re-tagged to include this action
+        uses: mongodb-labs/drivers-github-tools/code-scanning-export@main
+        with:
+          ref: main
+          output-file: sarif-report.json
+
+      - name: Get release version and release package file name
+        id: get_version
+        shell: bash
+        run: |
+          package_version=$(jq --raw-output '.version' package.json)
+          echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
+
+      - name: actions/publish_asset_to_s3
+        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@main
+        with:
+          version: ${{ steps.get_version.outputs.package_version }}
+          product_name: node-kerberos
+          file: sarif-report.json
+          # dry_run:  ${{ needs.release_please.outputs.release_created == '' }}
+          dry_run:  true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
   generate_sarif_report:
     environment: release
     runs-on: ubuntu-latest
-    # needs: [release_please]
+    needs: [release_please]
     permissions:
       # required for all workflows
       security-events: write
@@ -67,5 +67,4 @@ jobs:
           version: ${{ steps.get_version.outputs.package_version }}
           product_name: node-kerberos
           file: sarif-report.json
-          # dry_run:  ${{ needs.release_please.outputs.release_created == '' }}
-          dry_run:  false
+          dry_run:  ${{ needs.release_please.outputs.release_created == '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,7 @@ jobs:
           aws_secret_id: ${{ secrets.aws_secret_id }}
 
       - name: "Generate Sarif Report"
-        # TODO: Use v2 once it has been re-tagged to include this action
-        uses: mongodb-labs/drivers-github-tools/code-scanning-export@main
+        uses: mongodb-labs/drivers-github-tools/code-scanning-export@v2
         with:
           ref: main
           output-file: sarif-report.json
@@ -62,7 +61,7 @@ jobs:
           echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
 
       - name: actions/publish_asset_to_s3
-        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@main
+        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@v2
         with:
           version: ${{ steps.get_version.outputs.package_version }}
           product_name: node-kerberos
@@ -96,7 +95,7 @@ jobs:
           echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
 
       - name: actions/publish_asset_to_s3
-        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@main
+        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@v2
         with:
           version: ${{ steps.get_version.outputs.package_version }}
           product_name: node-kerberos


### PR DESCRIPTION
### Description

#### What is changing?

Sarif reports are generated and upload to s3 during the release process.

sbom lite files are also uploaded.

Example release upload for kerberos: 

![Screenshot 2024-06-12 at 10 48 25 AM](https://github.com/mongodb-js/kerberos/assets/23407842/24904571-e3cb-41d7-b0be-10e1b07aa0c9)

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
