### PR TITLE
chore: full SSDLC compliance workflow

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -96,14 +96,6 @@ functions:
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           NODE_GITHUB_TOKEN: ${github_token}
-  run prebuild and force publish:
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        script: >
-          ${PREPARE_SHELL}
-          NODE_FORCE_PUBLISH=1 NODE_GITHUB_TOKEN=${github_token} ${PROJECT_DIRECTORY}/.evergreen/run-prebuild.sh
   install dependencies:
     - command: subprocess.exec
       type: setup
@@ -138,65 +130,8 @@ tasks:
     commands:
       - func: install dependencies
       - func: run prebuild
-  - name: run-prebuild-force-publish
-    commands:
-      - func: install dependencies
-      - func: run prebuild and force publish
 
 buildvariants:
-  - name: macos
-    display_name: 'macOS 10.14'
-    run_on: macos-1014
-    tasks:
-      - run-prebuild
-      - run-prebuild-force-publish
-    expansions:
-      NODE_LTS_VERSION: 14
-      NPM_VERSION: 9
-  - name: macos-m1
-    display_name: MacOS M1
-    run_on: macos-1100-arm64
-    tasks:
-      - run-prebuild
-      - run-prebuild-force-publish
-    expansions:
-      NODE_LTS_VERSION: 18
-  - name: windows-x64
-    display_name: 'Windows 2016'
-    run_on: windows-64-vs2017-test
-    tasks:
-      - run-prebuild
-      - run-prebuild-force-publish
-  - name: rhel8-s390x
-    display_name: 'RHEL 8 s390x'
-    run_on: rhel83-zseries-small
-    expansions:
-      has_packages: true
-      packager_distro: rhel8
-      packager_arch: s390x
-    tasks:
-      - run-prebuild
-      - run-prebuild-force-publish
-  - name: ubuntu1804-64
-    display_name: 'Ubuntu 18.04 64-bit'
-    run_on: ubuntu1804-test
-    expansions:
-      has_packages: true
-      packager_distro: ubuntu1804
-      packager_arch: x86_64
-    tasks:
-      - run-prebuild
-      - run-prebuild-force-publish
-  - name: ubuntu1804-arm64
-    display_name: 'Ubuntu 18.04 arm64'
-    run_on: ubuntu1804-arm64-build
-    expansions:
-      has_packages: true
-      packager_distro: ubuntu1804
-      packager_arch: arm64
-    tasks:
-      - run-prebuild
-      - run-prebuild-force-publish
   - name: ubuntu2204-64
     display_name: 'Ubuntu 22.04 64-bit'
     run_on: ubuntu2204-small

--- a/.evergreen/run-prebuild.sh
+++ b/.evergreen/run-prebuild.sh
@@ -10,42 +10,6 @@ export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
 
 echo "Node Version $(node -v)"
 
-get_version_at_git_rev () {
-  local REV=$1
-  local VERSION
-  VERSION=$(node -r child_process -e "console.log(JSON.parse(child_process.execSync('git show $REV:./package.json', { encoding: 'utf8' })).version);")
-  echo "$VERSION"
-}
-
-run_prebuild() {
-  set +o xtrace # Don't log the token
-  if [[ -z $NODE_GITHUB_TOKEN ]];then
-    echo "No github token set. Cannot run prebuild."
-    exit 1
-  else
-    echo "Github token detected. Running prebuild."
-    npm run prebuild -- -u "${NODE_GITHUB_TOKEN}"
-    echo "Prebuild's successfully submitted"
-  fi
-  set -o xtrace
-}
-
-
-VERSION_AT_HEAD=$(get_version_at_git_rev "HEAD")
-VERSION_AT_HEAD_1=$(get_version_at_git_rev "HEAD~1")
-
-if [[ -n $NODE_FORCE_PUBLISH ]]; then
-  echo 'NODE_FORCE_PUBLISH detected'
-  echo "Beginning prebuild"
-  run_prebuild
-elif [[ $VERSION_AT_HEAD != "$VERSION_AT_HEAD_1" ]]; then
-  echo "Difference is package version ($VERSION_AT_HEAD_1 -> $VERSION_AT_HEAD)"
-  echo "Beginning prebuild"
-  run_prebuild
-else
-  echo "No difference is package version ($VERSION_AT_HEAD_1 -> $VERSION_AT_HEAD)"
-  echo "Will prebuild without submit"
-  npm run prebuild
-  echo "Local prebuild successful."
-  ls prebuilds
-fi
+npm run prebuild
+echo "Local prebuild successful."
+ls prebuilds

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,5 +11,5 @@ runs:
         registry-url: 'https://registry.npmjs.org'
     - run: npm install -g npm@latest
       shell: bash
-    - run: npm clean-install
+    - run: npm clean-install --ignore-scripts
       shell: bash

--- a/.github/docker/Dockerfile.glibc
+++ b/.github/docker/Dockerfile.glibc
@@ -1,0 +1,19 @@
+FROM ubuntu:bionic AS build
+
+# Possible values: s390x, arm64, x64
+ARG NODE_ARCH
+ADD https://nodejs.org/dist/v16.20.1/node-v16.20.1-linux-${NODE_ARCH}.tar.gz /
+RUN mkdir -p /nodejs && tar -xzf /node-v16.20.1-linux-${NODE_ARCH}.tar.gz --strip-components=1 -C /nodejs
+ENV PATH=$PATH:/nodejs/bin
+
+WORKDIR /kerberos
+COPY . .
+
+RUN apt-get -qq update && apt-get -qq install -y python3 build-essential && ldd --version
+
+RUN npm clean-install --ignore-scripts
+RUN npm run prebuild
+
+FROM scratch
+
+COPY --from=build /kerberos/prebuilds/ /

--- a/.github/docker/Dockerfile.glibc
+++ b/.github/docker/Dockerfile.glibc
@@ -9,7 +9,7 @@ ENV PATH=$PATH:/nodejs/bin
 WORKDIR /kerberos
 COPY . .
 
-RUN apt-get -qq update && apt-get -qq install -y python3 build-essential && ldd --version
+RUN apt-get -qq update && apt-get -qq install -y python3 build-essential libkrb5-dev && ldd --version
 
 RUN npm clean-install --ignore-scripts
 RUN npm run prebuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run Buildx
         run: |
           docker buildx create --name builder --bootstrap --use
-          docker buildx build --platform linux/${{ matrix.linux_arch }} --output type=local,dest=./prebuilds,platform-split=false -f ./.github/docker/Dockerfile.glibc .
+          docker buildx build --platform linux/${{ matrix.linux_arch }} --build-arg NODE_ARCH=${{ matrix.linux_arch == 'amd64' && 'x64' || matrix.linux_arch }} --output type=local,dest=./prebuilds,platform-split=false -f ./.github/docker/Dockerfile.glibc .
 
       - id: upload
         name: Upload prebuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch: {}
+  workflow_call: {}
 
 name: Build and Test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+name: Build and Test
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  host_builds:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-2019]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build ${{ matrix.os }} Prebuild
+        run: |
+          npm clean-install --ignore-scripts
+          npm run prebuild
+
+      - id: upload
+        name: Upload prebuild
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.os }}
+          path: prebuilds/
+          if-no-files-found: 'error'
+          retention-days: 1
+          compression-level: 0
+
+  container_builds:
+    outputs:
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        linux_arch: [s390x, arm64, amd64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run Buildx
+        run: |
+          docker buildx create --name builder --bootstrap --use
+          docker buildx build --platform linux/${{ matrix.linux_arch }} --output type=local,dest=./prebuilds,platform-split=false -f ./.github/docker/Dockerfile.glibc .
+
+      - id: upload
+        name: Upload prebuild
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-linux-${{ matrix.linux_arch }}
+          path: prebuilds/
+          if-no-files-found: 'error'
+          retention-days: 1
+          compression-level: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
           npm_package_name: kerberos
           dry_run: ${{ needs.release_please.outputs.release_created == '' }}
+          sign_native: true
 
       - name: Copy sbom file to release assets
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           dry_run: false
 
   publish:
-    needs: [release_please, build]
+    needs: [release_please, ssdlc, build]
     environment: release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Install Node and dependencies
         uses: baileympearson/drivers-github-tools/node/setup@add-signing-env-action-for-node
+        with:
+          ignore_install_scripts: true
 
       - name: Load version and package info
         uses: baileympearson/drivers-github-tools/node/get_version_info@add-signing-env-action-for-node
@@ -66,7 +68,6 @@ jobs:
           product_name: kerberos
           sarif_report_target_ref: main
           third_party_dependency_tool: n/a
-          # <package> and <package>.sig
           dist_filenames: artifacts/*
           token:  ${{ github.token }}
           sbom_file_name: sbom.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,42 @@
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch: {}
+
+name: Release
 
 permissions:
   contents: write
   pull-requests: write
   id-token: write
 
-name: release
-
 jobs:
-  release-please:
+  release_please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - id: release
         uses: googleapis/release-please-action@v4
 
-      # If release-please created a release, publish to npm
-      - if: ${{ steps.release.outputs.release_created }}
-        uses: actions/checkout@v4
-      - if: ${{ steps.release.outputs.release_created }}
-        name: actions/setup
-        uses: ./.github/actions/setup
-      - if: ${{ steps.release.outputs.release_created }}
-        run: npm publish --provenance
+  build:
+    needs: [release_please]
+    name: "Build native code"
+    uses: ./.github/workflows/build.yml
+
+  publish:
+    needs: [release_please, build]
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node and dependencies
+        uses: baileympearson/drivers-github-tools/node/setup@add-signing-env-action-for-node
+
+      - run: npm publish --provenance --tag=latest
+        if: ${{ needs.release_please.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch: {}
 
 name: Release
@@ -23,6 +25,58 @@ jobs:
     needs: [release_please]
     name: "Build native code"
     uses: ./.github/workflows/build.yml
+
+  ssdlc:
+    needs: [release_please, build]
+    permissions:
+      # required for all workflows
+      security-events: write
+      id-token: write
+      contents: write
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node and dependencies
+        uses: baileympearson/drivers-github-tools/node/setup@add-signing-env-action-for-node
+
+      - name: Load version and package info
+        uses: baileympearson/drivers-github-tools/node/get_version_info@add-signing-env-action-for-node
+        with:
+          npm_package_name: kerberos
+
+      - name: actions/sign_and_upload_package
+        uses: baileympearson/drivers-github-tools/node/sign_js_only_package@add-signing-env-action-for-node
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws_region_name: 'us-east-1'
+          aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
+          npm_package_name: kerberos
+          dry_run: ${{ needs.release_please.outputs.release_created == '' }}
+          sign_native: true
+
+      - name: Copy sbom file to release assets
+        shell: bash
+        run: cp sbom.json ${{ env.S3_ASSETS }}/sbom.json
+
+      - name: Generate authorized pub report
+        uses: mongodb-labs/drivers-github-tools/full-report@v2
+        with:
+          release_version: ${{ env.package_version }}
+          product_name: kerberos
+          sarif_report_target_ref: main
+          third_party_dependency_tool: n/a
+          # <package> and <package>.sig
+          dist_filenames: artifacts/*
+          token:  ${{ github.token }}
+          sbom_file_name: sbom.json
+
+      - uses: mongodb-labs/drivers-github-tools/upload-s3-assets@v2
+        with:
+          version: ${{ env.package_version }}
+          product_name: kerberos
+          dry_run: false
 
   publish:
     needs: [release_please, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,12 @@ on:
     branches: [main]
   workflow_dispatch: {}
 
-name: Release
-
 permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+name: release-latest
 
 jobs:
   release_please:
@@ -18,10 +18,12 @@ jobs:
     steps:
       - id: release
         uses: googleapis/release-please-action@v4
-
+        with:
+          target-branch: main
+  
   build:
     needs: [release_please]
-    name: "Build native code"
+    name: "Perform any build or bundling steps, as necessary."
     uses: ./.github/workflows/build.yml
 
   ssdlc:
@@ -44,15 +46,14 @@ jobs:
         with:
           npm_package_name: kerberos
 
-      - name: actions/sign_and_upload_package
-        uses: baileympearson/drivers-github-tools/node/sign_js_only_package@add-signing-env-action-for-node
+      - name: actions/compress_sign_and_upload
+        uses: baileympearson/drivers-github-tools/node/sign_node_package@add-signing-env-action-for-node
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws_region_name: 'us-east-1'
+          aws_region_name: us-east-1
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
           npm_package_name: kerberos
           dry_run: ${{ needs.release_please.outputs.release_created == '' }}
-          sign_native: true
 
       - name: Copy sbom file to release assets
         shell: bash
@@ -74,7 +75,7 @@ jobs:
         with:
           version: ${{ env.package_version }}
           product_name: kerberos
-          dry_run: false
+          dry_run: ${{ needs.release_please.outputs.release_created == '' }}
 
   publish:
     needs: [release_please, ssdlc, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch: {}
 
 name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: googleapis/release-please-action@v4
         with:
           target-branch: main
-  
+
   build:
     needs: [release_please]
     name: "Perform any build or bundling steps, as necessary."
@@ -67,7 +67,7 @@ jobs:
         if: ${{ '' != '' }}
         uses: mongodb-labs/drivers-github-tools/sbom@v2
         with:
-          silk_asset_group: ${{ '' }}
+          silk_asset_group: ''
           sbom_file_name: sbom.json
 
       - name: Generate authorized pub report
@@ -78,7 +78,7 @@ jobs:
           sarif_report_target_ref: main
           third_party_dependency_tool: n/a
           dist_filenames: artifacts/*
-          token:  ${{ github.token }}
+          token: ${{ github.token }}
           sbom_file_name: sbom.json
 
       - uses: mongodb-labs/drivers-github-tools/upload-s3-assets@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,16 @@ jobs:
 
       - name: Copy sbom file to release assets
         shell: bash
+        if: ${{ '' == '' }}
         run: cp sbom.json ${{ env.S3_ASSETS }}/sbom.json
+
+      # only used for mongodb-client-encryption
+      - name: Augment SBOM and copy to release assets
+        if: ${{ '' != '' }}
+        uses: mongodb-labs/drivers-github-tools/sbom@v2
+        with:
+          silk_asset_group: ${{ '' }}
+          sbom_file_name: sbom.json
 
       - name: Generate authorized pub report
         uses: mongodb-labs/drivers-github-tools/full-report@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,17 +39,17 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Node and dependencies
-        uses: baileympearson/drivers-github-tools/node/setup@add-signing-env-action-for-node
+        uses: mongodb-labs/drivers-github-tools/node/setup@v2
         with:
           ignore_install_scripts: true
 
       - name: Load version and package info
-        uses: baileympearson/drivers-github-tools/node/get_version_info@add-signing-env-action-for-node
+        uses: mongodb-labs/drivers-github-tools/node/get_version_info@v2
         with:
           npm_package_name: kerberos
 
       - name: actions/compress_sign_and_upload
-        uses: baileympearson/drivers-github-tools/node/sign_node_package@add-signing-env-action-for-node
+        uses: mongodb-labs/drivers-github-tools/node/sign_node_package@v2
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: us-east-1
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Node and dependencies
-        uses: baileympearson/drivers-github-tools/node/setup@add-signing-env-action-for-node
+        uses: mongodb-labs/drivers-github-tools/node/setup@v2
 
       - run: npm publish --provenance --tag=latest
         if: ${{ needs.release_please.outputs.release_created }}

--- a/README.md
+++ b/README.md
@@ -45,6 +45,49 @@ Now you can install `kerberos` with the following:
 npm install kerberos
 ```
 
+#### Prebuild Platforms
+
+Below are the platforms that are available as prebuilds on each github release.
+`prebuild-install` downloads these automatically depending on the platform you are running npm install on.
+
+- Linux GLIBC 2.23 or later
+    - s390x
+    - arm64
+    - x64
+- MacOS universal binary
+    - x64
+    - arm64
+- Windows
+    - x64
+
+### Release Integrity
+
+Releases are created automatically and signed using the [Node team's GPG key](https://pgp.mongodb.com/node-driver.asc). This applies to the git tag as well as all release packages provided as part of a GitHub release. To verify the provided packages, download the key and import it using gpg:
+
+```
+gpg --import node-driver.asc
+```
+
+The GitHub release contains a detached signature file for the NPM package (named
+`kerberos-X.Y.Z.tgz.sig`).
+
+The following command returns the link npm package. 
+```shell
+npm view kerberos@vX.Y.Z dist.tarball 
+```
+
+Using the result of the above command, a `curl` command can return the official npm package for the release.
+
+To verify the integrity of the downloaded package, run the following command:
+```shell
+gpg --verify kerberos-X.Y.Z.tgz.sig kerberos-X.Y.Z.tgz
+```
+
+>[!Note]
+No verification is done when using npm to install the package. To ensure release integrity when using npm, download the tarball manually from the GitHub release, verify the signature, then install the package from the downloaded tarball using npm install mongodb-X.Y.Z.tgz.
+
+To verify the native `.node` packages, follow the same steps as above. 
+
 ### Testing
 
 Run the test suite using:

--- a/binding.gyp
+++ b/binding.gyp
@@ -13,7 +13,15 @@
       'xcode_settings': {
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
         'CLANG_CXX_LIBRARY': 'libc++',
-        'MACOSX_DEPLOYMENT_TARGET': '10.12'
+        'MACOSX_DEPLOYMENT_TARGET': '10.12',
+        "OTHER_CFLAGS": [
+          "-arch x86_64",
+          "-arch arm64"
+        ],
+        "OTHER_LDFLAGS": [
+          "-arch x86_64",
+          "-arch arm64"
+        ]
       },
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "mocha": "^10.4.0",
         "mongodb": "^6.5.0",
         "node-gyp": "^10.1.0",
-        "prebuild": "^11.0.4",
+        "prebuild": "^13.0.0",
         "prettier": "^3.2.5",
         "request": "^2.88.2",
         "standard-version": "^9.5.0"
@@ -694,15 +694,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.2"
-      }
-    },
     "node_modules/ansi": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
@@ -934,11 +925,49 @@
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
       "dev": true
     },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
+      "dev": true
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bare-events": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -966,28 +995,6 @@
       "dev": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-      "dev": true,
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -1100,30 +1107,6 @@
       "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
       "dev": true
     },
-    "node_modules/buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha512-Zy8ZXMyxIT6RMTeY7OP/bDndfj6bwCan7SS98CEndS6deHwWPpseeHlwarNcBim+etXnF9HBc1non5JgDaJU1g==",
-      "dev": true
-    },
-    "node_modules/buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.2.0"
-      }
-    },
     "node_modules/cacache": {
       "version": "18.0.2",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.2.tgz",
@@ -1154,15 +1137,6 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/cacache/node_modules/fs-minipass": {
@@ -1230,81 +1204,6 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/cacache/node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/cacache/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cacache/node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
-      "dev": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cacache/node_modules/tar/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/cacache/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cacache/node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/cache-point": {
@@ -1408,18 +1307,6 @@
       "dev": true,
       "peerDependencies": {
         "chai": "^4.1.2"
-      }
-    },
-    "node_modules/chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-      "dev": true,
-      "dependencies": {
-        "traverse": ">=0.3.0 <0.4"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -1554,185 +1441,156 @@
       }
     },
     "node_modules/cmake-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-5.2.0.tgz",
-      "integrity": "sha512-/HLhzoBEOLKGdE1FLwH5ggzRt67AWTb4IErg4rm+bTC+R0DKUobojDyp17dSswDVPosdoPmHXjKxbJiyBZfQeg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-7.3.0.tgz",
+      "integrity": "sha512-dXs2zq9WxrV87bpJ+WbnGKv8WUBXDw8blNiwNHoRe/it+ptscxhQHKB1SJXa1w+kocLMeP28Tk4/eTCezg4o+w==",
       "dev": true,
       "dependencies": {
-        "bluebird": "^3",
+        "axios": "^1.6.5",
         "debug": "^4",
-        "fs-extra": "^5.0.0",
-        "is-iojs": "^1.0.1",
-        "lodash": "^4",
-        "memory-stream": "0",
-        "npmlog": "^1.2.0",
+        "fs-extra": "^11.2.0",
+        "lodash.isplainobject": "^4.0.6",
+        "memory-stream": "^1.0.0",
+        "node-api-headers": "^1.1.0",
+        "npmlog": "^6.0.2",
         "rc": "^1.2.7",
-        "request": "^2.54.0",
-        "semver": "^5.0.3",
-        "splitargs": "0",
-        "tar": "^4",
-        "traceur": "0.0.x",
-        "unzipper": "^0.8.13",
-        "url-join": "0",
-        "which": "^1.0.9",
-        "yargs": "^3.6.0"
+        "semver": "^7.5.4",
+        "tar": "^6.2.0",
+        "url-join": "^4.0.1",
+        "which": "^2.0.2",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "cmake-js": "bin/cmake-js"
       },
       "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 14.15.0"
       }
     },
     "node_modules/cmake-js/node_modules/are-we-there-yet": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-      "integrity": "sha512-Zfw6bteqM9gQXZ1BIWOgM8xEwMrUGoyL8nW13+O+OOgNX3YhuDN1GDgg1NzdTlmm3j+9sHy7uBZ12r+z9lXnZQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
       "dev": true,
       "dependencies": {
         "delegates": "^1.0.0",
-        "readable-stream": "^2.0.0 || ^1.1.13"
-      }
-    },
-    "node_modules/cmake-js/node_modules/camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
-      "dev": true,
+        "readable-stream": "^3.6.0"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/cmake-js/node_modules/cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/cmake-js/node_modules/gauge": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-      "integrity": "sha512-fVbU2wRE91yDvKUnrIaQlHKAWKY5e08PmztCrwuH5YVQ+Z/p3d0ny2T48o6uvAAXHIUnfaQdHkmxYbQft1eHVA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
       "dev": true,
       "dependencies": {
-        "ansi": "^0.3.0",
-        "has-unicode": "^2.0.0",
-        "lodash.pad": "^4.1.0",
-        "lodash.padend": "^4.1.0",
-        "lodash.padstart": "^4.1.0"
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cmake-js/node_modules/npmlog": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-      "integrity": "sha512-1J5KqSRvESP6XbjPaXt2H6qDzgizLTM7x0y1cXIjP2PpvdCqyNC7TO3cPRKsuYlElbi/DwkzRRdG2zpmE0IktQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
       "dev": true,
       "dependencies": {
-        "ansi": "~0.3.0",
-        "are-we-there-yet": "~1.0.0",
-        "gauge": "~1.2.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/cmake-js/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/cmake-js/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/cmake-js/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+    "node_modules/cmake-js/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
       "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/cmake-js/node_modules/wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
       }
     },
-    "node_modules/cmake-js/node_modules/y18n": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-      "dev": true
+    "node_modules/cmake-js/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/cmake-js/node_modules/yargs": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-      "integrity": "sha512-ONJZiimStfZzhKamYvR/xvmgW3uEkAUFSP91y2caTEPhzF6uP2JfPiVZcq66b/YR0C3uitxSV7+T1x8p5bkmMg==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "dependencies": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cmake-js/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/code-point-at": {
@@ -1774,6 +1632,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2988,6 +2855,12 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3149,6 +3022,26 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -3206,23 +3099,41 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/fs-minipass": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "dev": true,
       "dependencies": {
-        "minipass": "^2.6.0"
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/fs-then-native": {
@@ -3590,12 +3501,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
-    "node_modules/graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
-      "dev": true
-    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -3856,15 +3761,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
-    "node_modules/invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
@@ -3933,12 +3829,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-iojs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
-      "integrity": "sha512-tLn1j3wYSL6DkvEI+V/j0pKohpa5jk+ER74v6S4SgCXnjS0WA+DoZbwZBrrhgwksMvtuwndyGeG5F8YMsoBzSA==",
-      "dev": true
     },
     "node_modules/is-lambda": {
       "version": "1.0.1",
@@ -4213,10 +4103,13 @@
       "dev": true
     },
     "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4291,18 +4184,6 @@
         "graceful-fs": "^4.1.9"
       }
     },
-    "node_modules/lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
-      "dev": true,
-      "dependencies": {
-        "invert-kv": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4330,12 +4211,6 @@
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
-    },
-    "node_modules/listenercount": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-      "dev": true
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
@@ -4392,6 +4267,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -4560,37 +4441,13 @@
       "dev": true
     },
     "node_modules/memory-stream": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
-      "integrity": "sha512-q0D3m846qY6ZkIt+19ZemU5vH56lpOZZwoJc3AICARKh/menBuayQUjAGPrqtHQQMUYERSdOrej92J9kz7LgYA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-1.0.0.tgz",
+      "integrity": "sha512-Wm13VcsPIMdG96dzILfij09PvuS3APtcKNh7M28FsCA/w6+1mjR7hhPmfFNoilX9xU7wTdhsH5lJAm6XNzdtww==",
       "dev": true,
       "dependencies": {
-        "readable-stream": "~1.0.26-2"
+        "readable-stream": "^3.4.0"
       }
-    },
-    "node_modules/memory-stream/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
-    "node_modules/memory-stream/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/memory-stream/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true
     },
     "node_modules/meow": {
       "version": "8.1.2",
@@ -4843,13 +4700,12 @@
       }
     },
     "node_modules/minipass": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
       "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/minipass-collect": {
@@ -4897,31 +4753,6 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minipass-fetch/node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-fetch/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/minipass-flush": {
@@ -4996,19 +4827,29 @@
         "node": ">=8"
       }
     },
-    "node_modules/minipass/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
-    },
     "node_modules/minizlib": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "dev": true,
       "dependencies": {
-        "minipass": "^2.9.0"
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/mkdirp": {
@@ -5234,9 +5075,9 @@
       "dev": true
     },
     "node_modules/node-abi": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.45.0.tgz",
-      "integrity": "sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==",
+      "version": "3.65.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.65.0.tgz",
+      "integrity": "sha512-ThjYBfoDNr08AWx6hGaRbfPwxKV9kVzAzOzlLKbk2CuqXE2xnCh+cbAGnwM3t8Lq4v9rUB7VfondlkBckcJrVA==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -5262,6 +5103,12 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
+    },
+    "node_modules/node-api-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-1.1.0.tgz",
+      "integrity": "sha512-ucQW+SbYCUPfprvmzBsnjT034IGRB2XK8rRc78BgjNKhTdFKgAwAmgW704bKIBmcYW48it0Gkjpkd39Azrwquw==",
+      "dev": true
     },
     "node_modules/node-gyp": {
       "version": "10.1.0",
@@ -5294,39 +5141,6 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-gyp/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/node-gyp/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/node-gyp/node_modules/glob": {
@@ -5375,40 +5189,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/node-gyp/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/node-gyp/node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/node-gyp/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/node-gyp/node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -5419,23 +5199,6 @@
       },
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-gyp/node_modules/tar": {
-      "version": "6.1.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
-      "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
-      "dev": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -5877,18 +5640,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
-      "dev": true,
-      "dependencies": {
-        "lcid": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -5962,6 +5713,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6030,16 +5787,16 @@
       "dev": true
     },
     "node_modules/path-scurry": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
-      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6121,37 +5878,36 @@
       }
     },
     "node_modules/prebuild": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-11.0.4.tgz",
-      "integrity": "sha512-n23Rzql2m8ldFpwcFyouGUrg9VByEF2IroEZlNvPLiQwTJWucTNxIaZEoyVe2AxPRzQb6Eph2ytObxVWm4FA7Q==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-13.0.1.tgz",
+      "integrity": "sha512-AR+ZoFfG2qQM5iCtNNBWlueuzlBWQdeiU+fBF7ZwbW2w5p/2Ep1+3G4AtAymrMfZn0yg3DoF+xCorh5hHOJY/Q==",
       "dev": true,
       "dependencies": {
-        "cmake-js": "~5.2.0",
-        "detect-libc": "^2.0.0",
+        "cmake-js": "^7.3.0",
+        "detect-libc": "^2.0.2",
         "each-series-async": "^1.0.1",
         "execspawn": "^1.0.1",
         "ghreleases": "^3.0.2",
         "github-from-package": "0.0.0",
-        "glob": "^7.1.6",
-        "minimist": "^1.1.2",
-        "mkdirp": "^0.5.1",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^3.0.0",
-        "node-gyp": "^6.0.1",
-        "node-ninja": "^1.0.1",
-        "noop-logger": "^0.1.0",
+        "glob": "^10.3.10",
+        "minimist": "^1.2.8",
+        "napi-build-utils": "^1.0.2",
+        "node-abi": "^3.54.0",
+        "node-gyp": "^10.0.1",
+        "node-ninja": "^1.0.2",
+        "noop-logger": "^0.1.1",
         "npm-which": "^3.0.1",
-        "npmlog": "^4.0.1",
-        "nw-gyp": "^3.6.3",
-        "rc": "^1.0.3",
-        "run-waterfall": "^1.1.6",
-        "tar-stream": "^2.1.0"
+        "npmlog": "^7.0.1",
+        "nw-gyp": "^3.6.6",
+        "rc": "^1.2.8",
+        "run-waterfall": "^1.1.7",
+        "tar-stream": "^3.1.7"
       },
       "bin": {
         "prebuild": "bin.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -6179,78 +5935,170 @@
         "node": ">=10"
       }
     },
-    "node_modules/prebuild/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+    "node_modules/prebuild/node_modules/are-we-there-yet": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-4.0.2.tgz",
+      "integrity": "sha512-ncSWAawFhKMJDTdoAeOV+jyW1VCMj5QIAwULIBV0SSR7B/RLPPEQiknKcg/RIIZlUQrxELpsxMiTUoAQ4sIUyg==",
+      "deprecated": "This package is no longer supported.",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/prebuild/node_modules/node-gyp": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-6.1.0.tgz",
-      "integrity": "sha512-h4A2zDlOujeeaaTx06r4Vy+8MZ1679lU+wbCKDS4ZtvY2A37DESo37oejIw0mtmR3+rvNwts5B6Kpt1KrNYdNw==",
+    "node_modules/prebuild/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
-        "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.2",
-        "mkdirp": "^0.5.1",
-        "nopt": "^4.0.1",
-        "npmlog": "^4.1.2",
-        "request": "^2.88.0",
-        "rimraf": "^2.6.3",
-        "semver": "^5.7.1",
-        "tar": "^4.4.12",
-        "which": "^1.3.1"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/prebuild/node_modules/gauge": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-5.0.2.tgz",
+      "integrity": "sha512-pMaFftXPtiGIHCJHdcUUx9Rby/rFT/Kkt3fIIGCs+9PMDIljSyRiqraTlxNtBReJRDfUefpa263RQ3vnp5G/LQ==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^4.0.1",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/prebuild/node_modules/nopt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+    "node_modules/prebuild/node_modules/glob": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
+      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
       "dev": true,
       "dependencies": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
-        "nopt": "bin/nopt.js"
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/prebuild/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+    "node_modules/prebuild/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
+      "engines": {
+        "node": ">=8"
       }
     },
-    "node_modules/prebuild/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+    "node_modules/prebuild/node_modules/jackspeak": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
       "dev": true,
       "dependencies": {
-        "isexe": "^2.0.0"
+        "@isaacs/cliui": "^8.0.2"
       },
-      "bin": {
-        "which": "bin/which"
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/prebuild/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/prebuild/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/prebuild/node_modules/npmlog": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-7.0.1.tgz",
+      "integrity": "sha512-uJ0YFk/mCQpLBt+bxN88AKd+gyqZvZDbtiNxk6Waqcj2aPRyfVx8ITawkyQynxUagInjdYT1+qj4NfA5KJJUxg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "dependencies": {
+        "are-we-there-yet": "^4.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^5.0.0",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/prebuild/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/prebuild/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prebuild/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -6317,6 +6165,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -6379,6 +6233,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "dev": true
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -6772,15 +6632,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rsvp": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-      "dev": true,
-      "engines": {
-        "node": "0.12.* || 4.* || 6.* || >= 7.*"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6871,12 +6722,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "dev": true
     },
     "node_modules/shebang-command": {
@@ -7036,27 +6881,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-      "integrity": "sha512-gGKOSat73z0V8wBKo9AGxZZyekczBireh1hHktbt+kb9acsCB5OfVCF2DCWlztcQ3r5oNN7f2BL0B2xOcoJ/DQ==",
-      "dev": true,
-      "dependencies": {
-        "source-map": "0.1.32"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.1.32",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-      "integrity": "sha512-htQyLrrRLkQ87Zfrir4/yN+vAUd6DNjVayEjTSHXu29AYQJw57I4/xEL/M6p6E/woPNJwvZt6rVlzc7gFEJccQ==",
-      "dev": true,
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -7118,12 +6942,6 @@
       "dependencies": {
         "readable-stream": "^3.0.0"
       }
-    },
-    "node_modules/splitargs": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
-      "integrity": "sha512-UUFYD2oWbNwULH6WoVtLUOw8ch586B+HUqcsAjjjeoBQAM1bD4wZRXu01koaxyd8UeYpybWqW4h+lO1Okv40Tg==",
-      "dev": true
     },
     "node_modules/sshpk": {
       "version": "1.17.0",
@@ -7316,6 +7134,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
+      "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "queue-tick": "^1.0.1",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -7519,21 +7351,20 @@
       }
     },
     "node_modules/tar": {
-      "version": "4.4.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "dependencies": {
-        "chownr": "^1.1.4",
-        "fs-minipass": "^1.2.7",
-        "minipass": "^2.9.0",
-        "minizlib": "^1.3.3",
-        "mkdirp": "^0.5.5",
-        "safe-buffer": "^5.2.1",
-        "yallist": "^3.1.1"
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
       },
       "engines": {
-        "node": ">=4.5"
+        "node": ">=10"
       }
     },
     "node_modules/tar-fs": {
@@ -7572,23 +7403,14 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/tar/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+    "node_modules/tar/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
+      "engines": {
+        "node": ">=10"
       }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
     },
     "node_modules/temp-path": {
       "version": "1.0.0",
@@ -7619,6 +7441,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.0.tgz",
+      "integrity": "sha512-TmLJNj6UgX8xcUZo4UDStGQtDiTzF7BzWlzn9g7UWrjkpHr5uJTK1ld16wZ3LXb2vb6jH8qU89dW5whuMdXYdw==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-extensions": {
@@ -7711,71 +7542,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/traceur": {
-      "version": "0.0.111",
-      "resolved": "https://registry.npmjs.org/traceur/-/traceur-0.0.111.tgz",
-      "integrity": "sha512-Zy0NCrl3+k1VZvDrZGQJHjLM4Hwz7XHSedhVTdsbV3RNWVtgw/GUP44Rl5WqqcctLkzyQ60eTU2jxfLrlrjWZQ==",
-      "dev": true,
-      "dependencies": {
-        "commander": "2.9.x",
-        "glob": "5.0.x",
-        "rsvp": "^3.0.13",
-        "semver": "^4.3.3",
-        "source-map-support": "~0.2.8"
-      },
-      "bin": {
-        "traceur": "traceur"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/traceur/node_modules/commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
-      "dev": true,
-      "dependencies": {
-        "graceful-readlink": ">= 1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6.x"
-      }
-    },
-    "node_modules/traceur/node_modules/glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
-      "dev": true,
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/traceur/node_modules/semver": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-      "integrity": "sha512-IrpJ+yoG4EOH8DFWuVg+8H1kW1Oaof0Wxe7cPcXW3x9BjkN/eVo54F15LyqemnDIUYskQWr9qvl/RihmSy6+xQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/trim-newlines": {
@@ -7911,72 +7677,13 @@
       }
     },
     "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 10.0.0"
       }
-    },
-    "node_modules/unzipper": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
-      "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
-      "dev": true,
-      "dependencies": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "~1.0.10",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.1.5",
-        "setimmediate": "~1.0.4"
-      }
-    },
-    "node_modules/unzipper/node_modules/bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-      "dev": true
-    },
-    "node_modules/unzipper/node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/unzipper/node_modules/process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw==",
-      "dev": true
-    },
-    "node_modules/unzipper/node_modules/readable-stream": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-      "integrity": "sha512-NkXT2AER7VKXeXtJNSaWLpWIhmtSE3K2PguaLEeWr4JILghcIKqoLt1A3wHrnpDC5+ekf8gfk1GKWkFXe4odMw==",
-      "dev": true,
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/unzipper/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -7988,9 +7695,9 @@
       }
     },
     "node_modules/url-join": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-      "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
     },
     "node_modules/url-template": {
@@ -8097,18 +7804,6 @@
       "dev": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha512-2thx4pB0cV3h+Bw7QmMXcEbdmOzv9t0HFplJH/Lz6yu60hXYy5RT8rUu+wlIreVxWsGN20mo+MHeCSfUpQBwPw==",
-      "dev": true,
-      "bin": {
-        "window-size": "cli.js"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
       }
     },
     "node_modules/wordwrap": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,11 @@
     "request": "^2.88.2",
     "standard-version": "^9.5.0"
   },
+  "overrides": {
+    "prebuild": {
+      "node-gyp": "$node-gyp"
+    }
+  },
   "scripts": {
     "install": "prebuild-install --runtime napi || node-gyp rebuild",
     "format-cxx": "clang-format -i 'src/**/*'",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "mocha": "^10.4.0",
     "mongodb": "^6.5.0",
     "node-gyp": "^10.1.0",
-    "prebuild": "^11.0.4",
+    "prebuild": "^13.0.0",
     "prettier": "^3.2.5",
     "request": "^2.88.2",
     "standard-version": "^9.5.0"

--- a/test/kerberos_tests.js
+++ b/test/kerberos_tests.js
@@ -15,7 +15,7 @@ const port = process.env.KERBEROS_PORT || '80';
 
 describe('Kerberos', function () {
   before(function () {
-    if (os.type() === 'Windows_NT' || os.type() === 'Darwin') this.skip();
+    if (os.type() === 'Windows_NT') this.skip();
   });
 
   it('should lookup principal details on a server', function (done) {

--- a/test/kerberos_tests.js
+++ b/test/kerberos_tests.js
@@ -15,7 +15,7 @@ const port = process.env.KERBEROS_PORT || '80';
 
 describe('Kerberos', function () {
   before(function () {
-    if (os.type() === 'Windows_NT') this.skip();
+    if (os.type() === 'Windows_NT' || os.type() === 'Darwin') this.skip();
   });
 
   it('should lookup principal details on a server', function (done) {


### PR DESCRIPTION
### Description

#### What is changing?

Adds the full SSDLC release workflow for kerberos and builds our bindings in Github Actions.  Note that this also removes a portion of our evergreen CI matrix - as follow up work, we'll want to adjust the tests to run in Github actions as well.

Example successful run: https://github.com/mongodb-js/kerberos/actions/runs/9702370097

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
