### PR TITLE
fix(NODE-6253): use runtime linking against system kerberos libraries by default

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -124,7 +124,7 @@ tasks:
     commands:
       - func: run tests ubuntu
         vars:
-          GYP_DEFINES: kerberos_use_rtld=true
+          GYP_DEFINES: kerberos_use_rtld=false
           NPM_OPTIONS: --build-from-source
   - name: run-prebuild
     commands:

--- a/.github/scripts/build.mjs
+++ b/.github/scripts/build.mjs
@@ -19,7 +19,7 @@ async function parseArguments() {
   const pkg = JSON.parse(await fs.readFile(resolveRoot('package.json'), 'utf8'));
 
   const options = {
-    'kerberos_use_rtld': { type: 'boolean', default: false },
+    'kerberos_use_rtld': { type: 'boolean', default: true },
     help: { short: 'h', type: 'boolean', default: false }
   };
 
@@ -66,8 +66,8 @@ async function buildBindings(args, pkg) {
   // it will also produce `./prebuilds/kerberos-vVERSION-napi-vNAPI_VERSION-OS-ARCH.tar.gz`.
 
   let gypDefines = process.env.GYP_DEFINES ?? '';
-  if (args.kerberos_use_rtld) {
-    gypDefines += ' kerberos_use_rtld=true';
+  if (!args.kerberos_use_rtld) {
+    gypDefines += ' kerberos_use_rtld=false';
   }
 
   gypDefines = gypDefines.trim();

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,7 @@
       ],
       'variables': {
         'ARCH': '<(host_arch)',
-        'kerberos_use_rtld%': 'false'
+        'kerberos_use_rtld%': 'true'
       },
       'xcode_settings': {
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',


### PR DESCRIPTION
### Description

#### What is changing?

Set `kerberos_use_rtld` to true by default

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

See highlight

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fix segfault when running kerberos on systems with 1.x OpenSSL versions and Node.js 18+

Kerberos depends on OpenSSL and Node.js always bundles a copy of OpenSSL. Unfortunately an incompatiblity arises when Node's SSL version is not compatible with the version that the system kerberos library was built with. 

Kerberos will now load the system library by default with runtime dynamic linking. This enables us to specify that kerberos use the SSL version it was built against ([RTLD_DEEPBIND](https://linux.die.net/man/3/dlopen#:~:text=POSIX.1%2D2001.-,RTLD_DEEPBIND,-(since%20glibc%202.3.4))) so it does not adopt the symbols available in Node.js' address space. 

Starting in Node 18+ these Node's SSL symbols are from OpenSSL 3+, whereas on RHEL 8 the system SSL library is 1.1.1k. 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
