### PR TITLE
fix(NODE-6265): add Spectre Mitigation and CFG

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -21,15 +21,24 @@
       },
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
+      'msvs_configuration_attributes': {
+        'SpectreMitigation': 'Spectre'
+      },
       'msvs_settings': {
         'VCCLCompilerTool': {
           'ExceptionHandling': 1,
           'AdditionalOptions': [
+            '/guard:cf',
             '/w34244',
             '/w34267',
             '/ZH:SHA_256'
           ]
         },
+        'VCLinkerTool': {
+          'AdditionalOptions': [
+            '/guard:cf'
+          ]
+        }
       },
       'conditions': [
         ['OS=="mac"', { 'cflags+': ['-fvisibility=hidden'] }],

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "scripts": {
     "install": "prebuild-install --runtime napi || node-gyp rebuild",
-    "rebuild": "node-gyp rebuild",
     "format-cxx": "clang-format -i 'src/**/*'",
     "format-js": "eslint lib test --fix",
     "check:lint": "eslint lib test",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "scripts": {
     "install": "prebuild-install --runtime napi || node-gyp rebuild",
+    "rebuild": "node-gyp rebuild",
     "format-cxx": "clang-format -i 'src/**/*'",
     "format-js": "eslint lib test --fix",
     "check:lint": "eslint lib test",


### PR DESCRIPTION
### Description

#### What is changing?

This PR adds Spectre mitigation and control flow guards to the generated binaries by adding those flags to the binding.gyp file.

##### Is there new documentation needed for these changes?

Potentially. Enabling Spectre mitigation requires that package maintainers and contributors install Spectre-mitigated libraries for Visual Studio, assuming that Windows developers need to run `node-gyp rebuild`. In my case, it seems that the prebuild-install script runs and skips over the rebuild command. Non-Windows OSes should not be affected by this PR in general.

#### What is the motivation for this change?

BinSkim (a Microsoft binary analyzer) has identified that kerberos.node is missing Spectre mitigation and control flow guard flags. This issue affects the compliance of Visual Studio Code downstream along with the general security of the kerberos.node binary.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

### Double check the following

- [x] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
