### PR TITLE
chore: prepare for non-prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           ignore_install_scripts: true
 
-      - run: npm publish --provenance --tag=alpha
+      - run: npm publish --provenance
         if: ${{ needs.release_please.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,8 +9,7 @@
       "release-type": "node",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
-      "draft": false,
-      "prerelease": true
+      "draft": false
     }
   }
 }


### PR DESCRIPTION
### Description

#### What is changing?

- npm won't put alpha tag
- release-please will not make prerelease GH release

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

We're ready to publish the next kerberos version

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
