### PR TITLE
fix(NODE-6320): macos runtime linking name conflict with SSL

### DIFF
--- a/.github/scripts/build.mjs
+++ b/.github/scripts/build.mjs
@@ -87,6 +87,8 @@ async function buildBindings(args, pkg) {
     const x64Tar = `kerberos-v${pkg.version}-napi-v4-darwin-x64.tar.gz`;
     await fs.copyFile(resolveRoot('prebuilds', armTar), resolveRoot('prebuilds', x64Tar));
   }
+
+  await run('node', ['--print', `require('.')`], { cwd: resolveRoot() })
 }
 
 async function main() {

--- a/binding.gyp
+++ b/binding.gyp
@@ -61,7 +61,7 @@
             'src/unix/kerberos_unix.cc'
           ]
         }],
-        ['(OS=="mac" or OS=="linux") and (kerberos_use_rtld!="true")', {
+        ['(OS=="mac") or (OS=="linux" and kerberos_use_rtld!="true")', {
           'link_settings': {
             'libraries': [
               '-lkrb5',
@@ -78,7 +78,7 @@
             }]
           ]
         }],
-        ['(OS=="mac" or OS=="linux") and (kerberos_use_rtld=="true")', {
+        ['(OS=="linux") and (kerberos_use_rtld=="true")', {
           'defines': ['KERBEROS_USE_RTLD=1'],
           'link_settings': {
             'libraries': [


### PR DESCRIPTION
### Description

#### What is changing?

- Put the macos build back to dynamic linking instead of runtime linking

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

- On MacOS, libraries that the kerberos addon tries to load do not exist under the same names. This prevents the addon from loading.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### MacOS builds reverted to use dynamic linking

We recently made runtime linking with system kerberos libraries (#165) the default for Linux and MacOS (#188) platforms due to the fact that system kerberos libraries often link against the system SSL library. However, Node.js ships with it's own SSL library, and having both loaded when they are different versions would crash the addon. Inadvertently this did not work as intended on MacOS, so we're reverting the change for that platform, other platforms are unaffected.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
