### PR TITLE
chore(NODE-6322): fix codeQL CI checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,6 +47,7 @@ jobs:
     - if: matrix.build-mode == 'manual'
       shell: bash
       run: |
+        sudo apt-get update
         sudo apt-get install libkrb5-dev
         npm install
         npm run prebuild


### PR DESCRIPTION
### Description

#### What is changing?

Run apt update before apt install to get latest package information, fixing the 404 errors.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

CodeQL was not able to run.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
