### PR TITLE
feat(NODE-6333): Allow callers to specify the 'protect' flag

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -68,7 +68,6 @@ functions:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           PROJECT: ${project}
           GYP_DEFINES: ${GYP_DEFINES|}
-          NPM_OPTIONS: ${NPM_OPTIONS|}
         args:
           - run
           - '--interactive'
@@ -80,8 +79,6 @@ functions:
           - PROJECT_DIRECTORY=/app
           - '--env'
           - GYP_DEFINES
-          - '--env'
-          - NPM_OPTIONS
           - 'ubuntu:22.04'
           - /bin/bash
           - /app/.evergreen/run-tests-ubuntu.sh
@@ -125,7 +122,6 @@ tasks:
       - func: run tests ubuntu
         vars:
           GYP_DEFINES: kerberos_use_rtld=false
-          NPM_OPTIONS: --build-from-source
   - name: run-prebuild
     commands:
       - func: install dependencies

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -104,5 +104,5 @@ fi
 echo "npm location: $(which npm)"
 echo "npm version: $(npm -v)"
 
-npm install "${NPM_OPTIONS}" --build-from-source
+npm install --build-from-source
 ldd build/*/kerberos.node || true

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Processes a single kerberos client-side step using the supplied server challenge
 | challenge | <code>string</code> | The response returned after calling `unwrap` |
 | [options] | <code>object</code> | Optional settings |
 | [options.user] | <code>string</code> | The user to authorize |
+| [options.protect] | <code>boolean</code> | Indicates if the wrap should request message confidentiality |
 | [callback] | <code>function</code> |  |
 
 Perform the client side kerberos wrap step.

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -52,6 +52,7 @@ KerberosClient.prototype.step = defineOperation(KerberosClient.prototype.step, [
  * @param {string} challenge The response returned after calling `unwrap`
  * @param {object} [options] Optional settings
  * @param {string} [options.user] The user to authorize
+ * @param {string} [options.protect] Indicates if the wrap should request message confidentiality
  * @param {function} [callback]
  * @return {Promise} returns Promise if no callback passed
  */

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -52,7 +52,7 @@ KerberosClient.prototype.step = defineOperation(KerberosClient.prototype.step, [
  * @param {string} challenge The response returned after calling `unwrap`
  * @param {object} [options] Optional settings
  * @param {string} [options.user] The user to authorize
- * @param {string} [options.protect] Indicates if the wrap should request message confidentiality
+ * @param {boolean} [options.protect] Indicates if the wrap should request message confidentiality
  * @param {function} [callback]
  * @return {Promise} returns Promise if no callback passed
  */

--- a/src/kerberos.cc
+++ b/src/kerberos.cc
@@ -39,7 +39,7 @@ std::string ToStringWithNonStringAsEmpty(Napi::Value value) {
 
 int BooleanToIntWithNonIntAsFalse(Napi::Value value) {
     if (!value.IsBoolean()) {
-        return 0;
+        throw Error::New(value.Env(), "Expected a boolean value");
     }
     return value.As<Boolean>().Value() ? 1 : 0;
 }

--- a/src/kerberos.cc
+++ b/src/kerberos.cc
@@ -37,9 +37,9 @@ std::string ToStringWithNonStringAsEmpty(Napi::Value value) {
     return value.As<String>();
 }
 
-int BooleanToIntWithNonIntAsFalse(Napi::Value value) {
+int BooleanToIntWithNonIntAsError(Napi::Value value) {
     if (!value.IsBoolean()) {
-        throw Error::New(value.Env(), "Expected a boolean value");
+        throw TypeError::New(value.Env(), "Expected a boolean value");
     }
     return value.As<Boolean>().Value() ? 1 : 0;
 }

--- a/src/kerberos.cc
+++ b/src/kerberos.cc
@@ -37,11 +37,15 @@ std::string ToStringWithNonStringAsEmpty(Napi::Value value) {
     return value.As<String>();
 }
 
-int BooleanToIntWithNonIntAsError(Napi::Value value) {
-    if (!value.IsBoolean()) {
-        throw TypeError::New(value.Env(), "Expected a boolean value");
+int KerberosClient::ParseWrapOptionsProtect(const Napi::Object& options) {
+    if (!options.Has("protect"))    return 0;
+
+    if (!options.Get("protect").IsBoolean()) {
+        throw TypeError::New(options.Env(), "options.protect must be a boolean.");
     }
-    return value.As<Boolean>().Value() ? 1 : 0;
+
+    bool protect = options.Get("protect").As<Boolean>();
+    return protect ? 1 : 0;
 }
 
 Function KerberosClient::Init(Napi::Env env) {

--- a/src/kerberos.cc
+++ b/src/kerberos.cc
@@ -37,6 +37,13 @@ std::string ToStringWithNonStringAsEmpty(Napi::Value value) {
     return value.As<String>();
 }
 
+int BooleanToIntWithNonIntAsFalse(Napi::Value value) {
+    if (!value.IsBoolean()) {
+        return 0;
+    }
+    return value.As<Boolean>().Value() ? 1 : 0;
+}
+
 Function KerberosClient::Init(Napi::Env env) {
     return
         DefineClass(env,

--- a/src/kerberos.h
+++ b/src/kerberos.h
@@ -55,6 +55,8 @@ class KerberosClient : public Napi::ObjectWrap<KerberosClient> {
     void UnwrapData(const Napi::CallbackInfo& info);
     void WrapData(const Napi::CallbackInfo& info);
 
+    int ParseWrapOptionsProtect(const Napi::Object& options);
+
    private:
     friend class Napi::ObjectWrap<KerberosClient>;
     explicit KerberosClient(const Napi::CallbackInfo& info);
@@ -71,8 +73,6 @@ void CheckPassword(const Napi::CallbackInfo& info);
 void TestMethod(const Napi::CallbackInfo& info);
 
 std::string ToStringWithNonStringAsEmpty(Napi::Value value);
-
-int BooleanToIntWithNonIntAsError(Napi::Value value);
 
 }
 

--- a/src/kerberos.h
+++ b/src/kerberos.h
@@ -72,7 +72,7 @@ void TestMethod(const Napi::CallbackInfo& info);
 
 std::string ToStringWithNonStringAsEmpty(Napi::Value value);
 
-int BooleanToIntWithNonIntAsFalse(Napi::Value value);
+int BooleanToIntWithNonIntAsError(Napi::Value value);
 
 }
 

--- a/src/kerberos.h
+++ b/src/kerberos.h
@@ -72,6 +72,8 @@ void TestMethod(const Napi::CallbackInfo& info);
 
 std::string ToStringWithNonStringAsEmpty(Napi::Value value);
 
+int BooleanToIntWithNonIntAsFalse(Napi::Value value);
+
 }
 
 #endif  // KERBEROS_NATIVE_EXTENSION_H

--- a/src/unix/kerberos_unix.cc
+++ b/src/unix/kerberos_unix.cc
@@ -74,7 +74,7 @@ void KerberosClient::WrapData(const CallbackInfo& info) {
     Object options = info[1].ToObject();
     Function callback = info[2].As<Function>();
     std::string user = ToStringWithNonStringAsEmpty(options["user"]);
-    int protect = BooleanToIntWithNonIntAsFalse(options["protect"]);
+    int protect = BooleanToIntWithNonIntAsError(options["protect"]);
 
     KerberosWorker::Run(callback, "kerberos:ClientWrap", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         gss_result result = authenticate_gss_client_wrap(

--- a/src/unix/kerberos_unix.cc
+++ b/src/unix/kerberos_unix.cc
@@ -74,7 +74,7 @@ void KerberosClient::WrapData(const CallbackInfo& info) {
     Object options = info[1].ToObject();
     Function callback = info[2].As<Function>();
     std::string user = ToStringWithNonStringAsEmpty(options["user"]);
-    int protect = BooleanToIntWithNonIntAsError(options["protect"]);
+    int protect = ParseWrapOptionsProtect(options);
 
     KerberosWorker::Run(callback, "kerberos:ClientWrap", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         gss_result result = authenticate_gss_client_wrap(

--- a/src/unix/kerberos_unix.cc
+++ b/src/unix/kerberos_unix.cc
@@ -74,8 +74,7 @@ void KerberosClient::WrapData(const CallbackInfo& info) {
     Object options = info[1].ToObject();
     Function callback = info[2].As<Function>();
     std::string user = ToStringWithNonStringAsEmpty(options["user"]);
-
-    int protect = 0; // NOTE: this should be an option
+    int protect = BooleanToIntWithNonIntAsFalse(options["protect"]);
 
     KerberosWorker::Run(callback, "kerberos:ClientWrap", [=](KerberosWorker::SetOnFinishedHandler onFinished) {
         gss_result result = authenticate_gss_client_wrap(

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -92,7 +92,7 @@ void KerberosClient::WrapData(const CallbackInfo& info) {
     Object options = info[1].ToObject();
     Function callback = info[2].As<Function>();
     std::string user = ToStringWithNonStringAsEmpty(options["user"]);
-    int protect = 0; // NOTE: this should be an option
+    int protect = BooleanToIntWithNonIntAsFalse(options["protect"]);
 
     if (isStringTooLong(user)) {
         throw Error::New(info.Env(), "User name is too long");

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -92,7 +92,7 @@ void KerberosClient::WrapData(const CallbackInfo& info) {
     Object options = info[1].ToObject();
     Function callback = info[2].As<Function>();
     std::string user = ToStringWithNonStringAsEmpty(options["user"]);
-    int protect = BooleanToIntWithNonIntAsFalse(options["protect"]);
+    int protect = BooleanToIntWithNonIntAsError(options["protect"]);
 
     if (isStringTooLong(user)) {
         throw Error::New(info.Env(), "User name is too long");

--- a/src/win32/kerberos_win32.cc
+++ b/src/win32/kerberos_win32.cc
@@ -92,7 +92,7 @@ void KerberosClient::WrapData(const CallbackInfo& info) {
     Object options = info[1].ToObject();
     Function callback = info[2].As<Function>();
     std::string user = ToStringWithNonStringAsEmpty(options["user"]);
-    int protect = BooleanToIntWithNonIntAsError(options["protect"]);
+    int protect = ParseWrapOptionsProtect(options);
 
     if (isStringTooLong(user)) {
         throw Error::New(info.Env(), "User name is too long");

--- a/test/kerberos_tests.js
+++ b/test/kerberos_tests.js
@@ -122,4 +122,50 @@ describe('Kerberos', function () {
       });
     });
   });
+
+  describe('Client.wrap()', function () {
+    async function establishConext() {
+      const service = `HTTP@${hostname}`;
+      client = await kerberos.initializeClient(service, {});
+      server = await kerberos.initializeServer(service);
+      const clientResponse = await client.step('');
+      const serverResponse = await server.step(clientResponse);
+      await client.step(serverResponse);
+      expect(client.contextComplete).to.be.true;
+      return { client, server };
+    }
+
+    let client;
+    let server;
+
+    before(establishConext);
+    describe('options.protect', function () {
+      context('valid values for `protect`', function () {
+        test('no options provided', async function () {
+          await client.wrap('challenge');
+        });
+
+        test('options provided (protect omitted)', async function () {
+          await client.wrap('challenge', {});
+        });
+
+        test('protect = false', async function () {
+          await client.wrap('challenge', { protect: false });
+        });
+
+        test('protect = true', async function () {
+          await client.wrap('challenge', { protect: true });
+        });
+      });
+
+      context('when set to an invalid value', function () {
+        it('successfully wraps a payload', async function () {
+          const error = await client.wrap('challenge', { protect: 'non-boolean' }).catch(e => e);
+          expect(error)
+            .to.be.instanceOf(TypeError)
+            .to.match(/options.protect must be a boolean/);
+        });
+      });
+    });
+  });
 });

--- a/test/kerberos_tests.js
+++ b/test/kerberos_tests.js
@@ -4,6 +4,7 @@ const request = require('request');
 const chai = require('chai');
 const expect = chai.expect;
 const os = require('os');
+const { test } = require('mocha');
 chai.use(require('chai-string'));
 
 // environment variables
@@ -159,7 +160,7 @@ describe('Kerberos', function () {
       });
 
       context('when set to an invalid value', function () {
-        it('successfully wraps a payload', async function () {
+        it('throws a TypeError', async function () {
           const error = await client.wrap('challenge', { protect: 'non-boolean' }).catch(e => e);
           expect(error)
             .to.be.instanceOf(TypeError)


### PR DESCRIPTION
### Description

#### What is changing?

Allow callers to specify the `protect` flag. I did this by adding a new `BooleanToIntWithNonIntAsFalse()` function modeled off of `ToStringWithNonStringAsEmpty`. I use the new function to interpret the contents of `options["protect"]`.

I am not married to that function name and am happy to change it if there is a better choice.

##### Is there new documentation needed for these changes?

I've updated the `README`.

#### What is the motivation for this change?

Our server requires protected payloads. The library handles this just fine, but the `protect` flag is currently hard-coded to `0`. The caller should be able to influence its value.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `protect` is now an option for KerberosClient.wrap()

`protect` can be provided to `KerberosClient.wrap()`.  When configured, wrapped message will be encrypted.

Thanks @arabull for this contribution!  

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
  - The fix was modeled after `ToStringWithNonStringAsEmpty()`. I didn't see any tests for that guy and am unsure how to properly test the new function.
- [ ] New TODOs have a related JIRA ticket
  - n/a
