### PR TITLE
ci(NODE-6359): specify build-from-source once

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -68,7 +68,6 @@ functions:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           PROJECT: ${project}
           GYP_DEFINES: ${GYP_DEFINES|}
-          NPM_OPTIONS: ${NPM_OPTIONS|}
         args:
           - run
           - '--interactive'
@@ -80,8 +79,6 @@ functions:
           - PROJECT_DIRECTORY=/app
           - '--env'
           - GYP_DEFINES
-          - '--env'
-          - NPM_OPTIONS
           - 'ubuntu:22.04'
           - /bin/bash
           - /app/.evergreen/run-tests-ubuntu.sh
@@ -125,7 +122,6 @@ tasks:
       - func: run tests ubuntu
         vars:
           GYP_DEFINES: kerberos_use_rtld=false
-          NPM_OPTIONS: --build-from-source
   - name: run-prebuild
     commands:
       - func: install dependencies

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -104,5 +104,5 @@ fi
 echo "npm location: $(which npm)"
 echo "npm version: $(npm -v)"
 
-npm install "${NPM_OPTIONS}" --build-from-source
+npm install --build-from-source
 ldd build/*/kerberos.node || true


### PR DESCRIPTION
### Description

#### What is changing?

Half of CI already specified build-from-source, and specifying `build-from-source` more than once actually reverts to downloading prebuilds.  So the other half of CI wasn't testing against source code.

This PR removes all instances of `NPM_OPTIONS` and ensures we always build from source.


##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
