### PR TITLE
fix(NODE-6372): correctly GSS wrap non-user data

### DIFF
--- a/src/unix/kerberos_gss.cc
+++ b/src/unix/kerberos_gss.cc
@@ -468,7 +468,7 @@ gss_result authenticate_gss_client_wrap(gss_client_state* state,
         input_token.length = len;
     }
 
-    if (user) {
+    if (user && *user) {
         // get bufsize
         // server_conf_flags = ((char*) input_token.value)[0];
         ((char*)input_token.value)[0] = 0;

--- a/test/kerberos_tests.js
+++ b/test/kerberos_tests.js
@@ -168,5 +168,24 @@ describe('Kerberos', function () {
         });
       });
     });
+
+    describe('options.user', function () {
+      context('valid values for `user`', function () {
+        test('no options provided', async function () {
+          const rs = await client.wrap('x'.repeat(100));
+          expect(rs).length.to.be.greaterThan(100);
+        });
+
+        test('options provided (user omitted)', async function () {
+          const rs = await client.wrap('x'.repeat(100), {});
+          expect(rs).length.to.be.greaterThan(100);
+        });
+
+        test('options provided (user set)', async function () {
+          const rs = await client.wrap('x'.repeat(100), { user: 'foo' });
+          expect(rs).length.to.be.lessThan(100);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
### Description

Fix implementation of `wrap` function to work for use cases other than authentication.

#### What is changing?

Just an extra check for an empty string: `if (user)` becomes `if (user && *user)`.

Without this, the `wrap` function was discarding the challenge/payload value and wrapping only the user option value, even if no such value was provided.

##### Is there new documentation needed for these changes?

No, this makes the `wrap` method work as per the existing documentation.

#### What is the motivation for this change?

Without this change, the `wrap` function works only for authentication. With this change, any payload can be GSS-wrapped.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Allow Kerberos GSS `wrap` function to work on arbitrary challenge/payload data, not just user authentication.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
