### PR TITLE
ci(NODE-6561): run on matrix of supported node versions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -39,6 +39,7 @@ functions:
           - '.evergreen/run-tests.sh'
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
+          NODE_LTS_VERSION: ${NODE_LTS_VERSION}
   run tests ubuntu:
     - command: subprocess.exec
       type: test
@@ -47,6 +48,7 @@ functions:
         working_dir: src
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
+          NODE_LTS_VERSION: ${NODE_LTS_VERSION}
           PROJECT: ${project}
           GYP_DEFINES: ${GYP_DEFINES|}
         args:
@@ -64,6 +66,8 @@ functions:
           - DRIVERS_TOOLS=/drivers-tools
           - '--env'
           - GYP_DEFINES
+          - '--env'
+          - NODE_LTS_VERSION=${NODE_LTS_VERSION}
           - 'ubuntu:22.04'
           - /bin/bash
           - /app/.evergreen/run-tests-ubuntu.sh
@@ -114,23 +118,91 @@ tasks:
       - func: run prebuild
 
 buildvariants:
-  - name: ubuntu2204-64
-    display_name: 'Ubuntu 22.04 64-bit'
+  - name: ubuntu2204-64-node-16
+    display_name: 'Ubuntu 22.04 64-bit - Node 16'
     run_on: ubuntu2204-small
     expansions:
       has_packages: true
       packager_distro: ubuntu2204
       packager_arch: x86_64
+      NODE_LTS_VERSION: "16"
     tasks:
       - run-tests-ubuntu
       - run-tests-ubuntu-rtld
-  - name: ubuntu2204-arm64
-    display_name: 'Ubuntu 22.04 arm64'
+  - name: ubuntu2204-64-node-18
+    display_name: 'Ubuntu 22.04 64-bit - Node 18'
+    run_on: ubuntu2204-small
+    expansions:
+      has_packages: true
+      packager_distro: ubuntu2204
+      packager_arch: x86_64
+      NODE_LTS_VERSION: "18"
+    tasks:
+      - run-tests-ubuntu
+      - run-tests-ubuntu-rtld
+  - name: ubuntu2204-64-node-20
+    display_name: 'Ubuntu 22.04 64-bit - Node 20'
+    run_on: ubuntu2204-small
+    expansions:
+      has_packages: true
+      packager_distro: ubuntu2204
+      packager_arch: x86_64
+      NODE_LTS_VERSION: "20"
+    tasks:
+      - run-tests-ubuntu
+      - run-tests-ubuntu-rtld
+  - name: ubuntu2204-64-node-22
+    display_name: 'Ubuntu 22.04 64-bit - Node 22'
+    run_on: ubuntu2204-small
+    expansions:
+      has_packages: true
+      packager_distro: ubuntu2204
+      packager_arch: x86_64
+      NODE_LTS_VERSION: "22"
+    tasks:
+      - run-tests-ubuntu
+      - run-tests-ubuntu-rtld
+  - name: ubuntu2204-arm64-node-16
+    display_name: 'Ubuntu 22.04 arm64 - Node 16'
     run_on: ubuntu2204-arm64-small
     expansions:
       has_packages: true
       packager_distro: ubuntu2204
       packager_arch: arm64
+      NODE_LTS_VERSION: "16"
+    tasks:
+      - run-tests-ubuntu
+      - run-tests-ubuntu-rtld
+  - name: ubuntu2204-arm64-node-18
+    display_name: 'Ubuntu 22.04 arm64 - Node 18'
+    run_on: ubuntu2204-arm64-small
+    expansions:
+      has_packages: true
+      packager_distro: ubuntu2204
+      packager_arch: arm64
+      NODE_LTS_VERSION: "18"
+    tasks:
+      - run-tests-ubuntu
+      - run-tests-ubuntu-rtld
+  - name: ubuntu2204-arm64-node-20
+    display_name: 'Ubuntu 22.04 arm64 - Node 20'
+    run_on: ubuntu2204-arm64-small
+    expansions:
+      has_packages: true
+      packager_distro: ubuntu2204
+      packager_arch: arm64
+      NODE_LTS_VERSION: "20"
+    tasks:
+      - run-tests-ubuntu
+      - run-tests-ubuntu-rtld
+  - name: ubuntu2204-arm64-node-22
+    display_name: 'Ubuntu 22.04 arm64 - Node 22'
+    run_on: ubuntu2204-arm64-small
+    expansions:
+      has_packages: true
+      packager_distro: ubuntu2204
+      packager_arch: arm64
+      NODE_LTS_VERSION: "22"
     tasks:
       - run-tests-ubuntu
       - run-tests-ubuntu-rtld

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -68,6 +68,8 @@ functions:
           - GYP_DEFINES
           - '--env'
           - NODE_LTS_VERSION=${NODE_LTS_VERSION}
+          - '--env'
+          - NPM_VERSION=${NPM_VERSION}
           - 'ubuntu:22.04'
           - /bin/bash
           - /app/.evergreen/run-tests-ubuntu.sh
@@ -126,6 +128,7 @@ buildvariants:
       packager_distro: ubuntu2204
       packager_arch: x86_64
       NODE_LTS_VERSION: "16"
+      NPM_VERSION: "9"
     tasks:
       - run-tests-ubuntu
       - run-tests-ubuntu-rtld
@@ -170,6 +173,7 @@ buildvariants:
       packager_distro: ubuntu2204
       packager_arch: arm64
       NODE_LTS_VERSION: "16"
+      NPM_VERSION: "9"
     tasks:
       - run-tests-ubuntu
       - run-tests-ubuntu-rtld

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -120,8 +120,8 @@ tasks:
       - func: run prebuild
 
 buildvariants:
-  - name: ubuntu2204-64-node-16
-    display_name: 'Ubuntu 22.04 64-bit - Node 16'
+  - name: ubuntu2204-x64-node-16
+    display_name: 'Ubuntu 22.04 x64 - Node 16'
     run_on: ubuntu2204-small
     expansions:
       has_packages: true
@@ -132,8 +132,8 @@ buildvariants:
     tasks:
       - run-tests-ubuntu
       - run-tests-ubuntu-rtld
-  - name: ubuntu2204-64-node-18
-    display_name: 'Ubuntu 22.04 64-bit - Node 18'
+  - name: ubuntu2204-x64-node-18
+    display_name: 'Ubuntu 22.04 x64 - Node 18'
     run_on: ubuntu2204-small
     expansions:
       has_packages: true
@@ -143,8 +143,8 @@ buildvariants:
     tasks:
       - run-tests-ubuntu
       - run-tests-ubuntu-rtld
-  - name: ubuntu2204-64-node-20
-    display_name: 'Ubuntu 22.04 64-bit - Node 20'
+  - name: ubuntu2204-x64-node-20
+    display_name: 'Ubuntu 22.04 x64 - Node 20'
     run_on: ubuntu2204-small
     expansions:
       has_packages: true
@@ -154,8 +154,8 @@ buildvariants:
     tasks:
       - run-tests-ubuntu
       - run-tests-ubuntu-rtld
-  - name: ubuntu2204-64-node-22
-    display_name: 'Ubuntu 22.04 64-bit - Node 22'
+  - name: ubuntu2204-x64-node-22
+    display_name: 'Ubuntu 22.04 x64 - Node 22'
     run_on: ubuntu2204-small
     expansions:
       has_packages: true

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -10,6 +10,8 @@ export NODE_LTS_VERSION=${NODE_LTS_VERSION:-14}
 # a version lower than latest to support EOL Node versions.
 export NPM_VERSION=${NPM_VERSION:-latest}
 
+echo "Installing Node.js $NODE_LTS_VERSION with npm@$NPM_VERSION"
+
 source $DRIVERS_TOOLS/.evergreen/install-node.sh
 
 npm install --build-from-source

--- a/.evergreen/run-tests-ubuntu.sh
+++ b/.evergreen/run-tests-ubuntu.sh
@@ -14,6 +14,8 @@ export KERBEROS_PORT="80"
 export KERBEROS_HOSTNAME=$HOSTNAME.$KERBEROS_REALM
 export DEBIAN_FRONTEND=noninteractive
 
+export NODE_LTS_VERSION=$NODE_LTS_VERSION
+
 echo "Installing all the packages required in this test"
 apt-get update
 apt-get -y -qq install \
@@ -123,8 +125,7 @@ else
     echo -e "SUCCESS: Apache site built and set for Kerberos auth\nActual Output:\n$CURL_OUTPUT"
 fi
 
-echo "Run: install Node.js 22"
-export NODE_LTS_VERSION=22
+echo "Run: install Node.js"
 source "${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
 
 npm test

--- a/.evergreen/run-tests-ubuntu.sh
+++ b/.evergreen/run-tests-ubuntu.sh
@@ -123,8 +123,8 @@ else
     echo -e "SUCCESS: Apache site built and set for Kerberos auth\nActual Output:\n$CURL_OUTPUT"
 fi
 
-echo "Run: install Node.js 20"
-export NODE_LTS_VERSION=20
+echo "Run: install Node.js 22"
+export NODE_LTS_VERSION=22
 source "${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
 
 npm test


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
