### PR TITLE
fix(NODE-6592): remove dependency on `bindings`

### DIFF
--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -1,17 +1,11 @@
 'use strict';
 
-function load() {
-  try {
-    return require('../build/Release/kerberos.node');
-  } catch {
-    return require('../build/Debug/kerberos.node');
-  }
-}
+const { loadBindings, defineOperation } = require('./util');
 
-const kerberos = load();
+
+const kerberos = loadBindings();
 const KerberosClient = kerberos.KerberosClient;
 const KerberosServer = kerberos.KerberosServer;
-const defineOperation = require('./util').defineOperation;
 
 // GSS Flags
 const GSS_C_DELEG_FLAG = 1;

--- a/lib/kerberos.js
+++ b/lib/kerberos.js
@@ -1,6 +1,14 @@
 'use strict';
 
-const kerberos = require('bindings')('kerberos');
+function load() {
+  try {
+    return require('../build/Release/kerberos.node');
+  } catch {
+    return require('../build/Debug/kerberos.node');
+  }
+}
+
+const kerberos = load();
 const KerberosClient = kerberos.KerberosClient;
 const KerberosServer = kerberos.KerberosServer;
 const defineOperation = require('./util').defineOperation;

--- a/lib/util.js
+++ b/lib/util.js
@@ -19,8 +19,7 @@ function validateParameter(parameter, specs, specIndex) {
     }
 
     throw new TypeError(
-      `Invalid type for parameter \`${spec.name}\`, expected \`${
-        spec.type
+      `Invalid type for parameter \`${spec.name}\`, expected \`${spec.type
       }\` but found \`${typeof parameter}\``
     );
   }
@@ -81,4 +80,12 @@ function defineOperation(fn, paramDefs) {
   };
 }
 
-module.exports = { defineOperation, validateParameter };
+function loadBindings() {
+  try {
+    return require('../build/Release/kerberos.node');
+  } catch {
+    return require('../build/Debug/kerberos.node');
+  }
+}
+
+module.exports = { defineOperation, validateParameter, loadBindings };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "bindings": "^1.5.0",
         "node-addon-api": "^6.1.0",
         "prebuild-install": "^7.1.2"
       },
@@ -859,14 +858,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -2271,11 +2262,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/fill-range": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "url": "https://jira.mongodb.org/projects/NODE/issues/"
   },
   "dependencies": {
-    "bindings": "^1.5.0",
     "node-addon-api": "^6.1.0",
     "prebuild-install": "^7.1.2"
   },

--- a/test/defineOperation_tests.js
+++ b/test/defineOperation_tests.js
@@ -1,5 +1,8 @@
 'use strict';
-const kerberos = require('../lib/kerberos');
+
+const { loadBindings } = require('../lib/util');
+
+const kerberos = loadBindings();
 const defineOperation = require('../lib/util').defineOperation;
 const expect = require('chai').expect;
 

--- a/test/defineOperation_tests.js
+++ b/test/defineOperation_tests.js
@@ -1,5 +1,5 @@
 'use strict';
-const kerberos = require('bindings')('kerberos');
+const kerberos = require('../lib/kerberos');
 const defineOperation = require('../lib/util').defineOperation;
 const expect = require('chai').expect;
 
@@ -16,7 +16,7 @@ describe('defineOperation', () => {
   });
 
   it('should validate optional parameters, with valid parameters after', function () {
-    expect(() => testMethod('llamas', false, true, () => {})).to.throw(
+    expect(() => testMethod('llamas', false, true, () => { })).to.throw(
       /Invalid type for parameter `optionalString`/
     );
   });


### PR DESCRIPTION
### Description

#### What is changing?

Remove `bindings` as a production dependency.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
