### PR TITLE
feat(NODE-6932): Add Windows 11 + ARM64 to supported build hosts.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   host_builds:
     strategy:
       matrix:
-        os: [macos-latest, windows-2019]
+        os: [macos-latest, windows-2019, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Description

#### What is changing?

This PR adds a runner for Windows 11 on ARM64. Currently the runner is in a preview state according to [the docs on GitHub hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners?supported-runners-and-hardware-resources=); however, Windows ARM64 support currently has a gap.

##### Is there new documentation needed for these changes?

Other than in `README.md`, just in the changelog/`HISTORY.md`.

#### What is the motivation for this change?

Desire to support Windows+ARM64.

https://jira.mongodb.org/browse/NODE-6932

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
