### PR TITLE
feat(NODE-6993): Add support for FreeBSD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           arch: ${{ matrix.freebsd_arch }}
           usesh: true
           prepare: |
-            pkg install -y node npm
+            pkg install -y krb5 node npm
           run: |
             node .github/scripts/build.mjs
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           arch: ${{ matrix.freebsd_arch }}
           usesh: true
           prepare: |
-            pkg install -y krb5 node npm
+            pkg install -y krb5 node npm pkgconf
           run: |
             node .github/scripts/build.mjs
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,3 +63,29 @@ jobs:
           if-no-files-found: 'error'
           retention-days: 1
           compression-level: 0
+
+  freebsd_builds:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        freebsd_arch: [aarch64, amd64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build FreeBSD ${{ matrix.freebsd_arch }} Prebuild
+        uses: vmactions/freebsd-vm@v1
+        with:
+          arch: ${{ matrix.freebsd_arch }}
+          usesh: true
+          run: |
+            node .github/scripts/build.mjs
+
+      - id: upload
+        name: Upload prebuild
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-freebsd-${{ matrix.freebsd_arch }}
+          path: prebuilds/
+          if-no-files-found: 'error'
+          retention-days: 1
+          compression-level: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,8 @@ jobs:
         with:
           arch: ${{ matrix.freebsd_arch }}
           usesh: true
+          prepare: |
+            pkg install -y node
           run: |
             node .github/scripts/build.mjs
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           arch: ${{ matrix.freebsd_arch }}
           usesh: true
           prepare: |
-            pkg install -y node
+            pkg install -y node npm
           run: |
             node .github/scripts/build.mjs
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build FreeBSD ${{ matrix.freebsd_arch }} Prebuild
+      - name: Build freebsd-${{ matrix.freebsd_arch }} Prebuild
         uses: vmactions/freebsd-vm@v1
         with:
           arch: ${{ matrix.freebsd_arch }}

--- a/binding.gyp
+++ b/binding.gyp
@@ -87,12 +87,12 @@
           },
         }],
         ['OS=="freebsd"', {
-          'include_dirs': [
-            '/usr/local/include',
+          'include_dirs+': [
+            '<!(pkg-config krb5 --cflags-only-I | sed -E "s/(-I *|-isystem *)//g")',
           ],
           'link_settings': {
             'library_dirs': [
-              '/usr/local/lib',
+              '<!(pkg-config krb5 --libs-only-L | sed -e "s/-L//g")',
             ]
           },
         }],

--- a/binding.gyp
+++ b/binding.gyp
@@ -54,14 +54,14 @@
             ]
           }
         }],
-        ['OS=="mac" or OS=="linux"', {
+        ['OS=="mac" or OS=="linux" or OS=="freebsd"', {
           'sources': [
             'src/unix/base64.cc',
             'src/unix/kerberos_gss.cc',
             'src/unix/kerberos_unix.cc'
           ]
         }],
-        ['(OS=="mac") or (OS=="linux" and kerberos_use_rtld!="true")', {
+        ['(OS=="mac") or ((OS=="linux" or OS=="freebsd") and kerberos_use_rtld!="true")', {
           'link_settings': {
             'libraries': [
               '-lkrb5',
@@ -78,7 +78,7 @@
             }]
           ]
         }],
-        ['(OS=="linux") and (kerberos_use_rtld=="true")', {
+        ['(OS=="linux" or OS=="freebsd") and (kerberos_use_rtld=="true")', {
           'defines': ['KERBEROS_USE_RTLD=1'],
           'link_settings': {
             'libraries': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -86,6 +86,16 @@
             ]
           },
         }],
+        ['OS=="freebsd"', {
+          'include_dirs': [
+            '/usr/local/include',
+          ],
+          'link_settings': {
+            'library_dirs': [
+              '/usr/local/lib',
+            ]
+          },
+        }],
         ['OS=="win"',  {
           'sources': [
             'src/win32/kerberos_sspi.cc',

--- a/src/kerberos_common.h
+++ b/src/kerberos_common.h
@@ -1,7 +1,7 @@
 #ifndef KERBEROS_COMMON_H
 #define KERBEROS_COMMON_H
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 #include "unix/kerberos_gss.h"
 
 namespace node_kerberos {

--- a/src/unix/kerberos_gss.cc
+++ b/src/unix/kerberos_gss.cc
@@ -65,10 +65,17 @@ struct DLOpenHandle {
   DLOpenHandle& operator=(DLOpenHandle&) = delete;
 };
 
+#ifndef __FreeBSD__
 #define DYLIBS(V) \
     V(gssapi, "libgssapi_krb5.so.2") \
     V(krb5, "libkrb5.so.3") \
     V(comerr, "libcom_err.so.2")
+#else
+#define DYLIBS(V) \
+    V(gssapi, "libgssapi_krb5.so.2") \
+    V(krb5, "libkrb5.so.3") \
+    V(comerr, "libcom_err.so.3")
+#endif
 
 #define LIBRARY_HANDLE_GETTER(name, lib) \
     static const DLOpenHandle& name ## _handle() { \


### PR DESCRIPTION
### Description

This PR contains a set of changes necessary for building this node module on FreeBSD.

#### What is changing?

Add conditions for enabling build on FreeBSD, namely:
- change `OS=="linux"` to `OS=="linux" or OS=="freebsd"` in `binding.gyp`,
- add `defined(__FreeBSD__)` in `src/kerberos_common.h` so that the UNIX-related sources are used.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

With the proposed change, FreeBSD users can use this node module on their systems.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Add support for FreeBSD

FreeBSD is now an unofficially supported platform. Thank you to [tagattie](https://github.com/tagattie) for the contribution.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
