### PR TITLE
feat(NODE-7051): Normalize casing of shlwapi.lib

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -105,7 +105,7 @@
             'libraries': [
               '-lcrypt32',
               '-lsecur32',
-              '-lShlwapi'
+              '-lshlwapi'
             ]
           }
         }]


### PR DESCRIPTION
I ran into this cross-compiling on a case-sensitive file-system. The official sdk uses `Shlwapi.h` and `ShLwApi.Lib`, but it is simplest to keep library names lowercase.

### Description

#### What is changing?

Casing of `-lshlwapi` compile flag on windows, to ease cross-compilation.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

Issue observed when using msvc on linux.

### Improved dependency handling of shlwapi.lib

Library now handles situation on Windows where the casing of the library differs or the case sensitivity of the file system differs. Thanks to @tmm1 for the contribution.

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
