### PR TITLE
fix(NODE-7064): bump prebuild-install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.2"
+        "prebuild-install": "^7.1.3"
       },
       "devDependencies": {
         "@types/node": "^22.15.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "node-addon-api": "^6.1.0",
-    "prebuild-install": "^7.1.2"
+    "prebuild-install": "^7.1.3"
   },
   "devDependencies": {
     "@types/node": "^22.15.3",


### PR DESCRIPTION
### Description

Bumps prebuild-install to 7.1.3

#### What is changing?

Update package.json

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-7064

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Bumps prebuild-install to ^7.1.3

This fixes an undefined N-API target issue with 7.1.2

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
