### PR TITLE
feat(NODE-7166)!: increase napi version to 9

### DIFF
--- a/.github/scripts/build.mjs
+++ b/.github/scripts/build.mjs
@@ -2,7 +2,7 @@
 
 import util from 'node:util';
 import process from 'node:process';
-import fs from 'node:fs/promises';
+import fs, { readFile } from 'node:fs/promises';
 import child_process from 'node:child_process';
 import events from 'node:events';
 import path from 'node:path';
@@ -84,7 +84,13 @@ async function buildBindings(args, pkg) {
   if (process.platform === 'darwin' && process.arch === 'arm64') {
     // The "arm64" build is actually a universal binary
     // @ts-ignore
-    const napiVersion = require('../../package.json').binary.napi_versions[0];
+    const {
+      binary: {
+        napi_versions: [
+          napiVersion
+        ]
+      }
+    } = JSON.parse(await readFile(resolveRoot('package.json'), 'utf-8'));
     const armTar = `kerberos-v${pkg.version}-napi-v${napiVersion}-darwin-arm64.tar.gz`;
     const x64Tar = `kerberos-v${pkg.version}-napi-v${napiVersion}-darwin-x64.tar.gz`;
     await fs.copyFile(resolveRoot('prebuilds', armTar), resolveRoot('prebuilds', x64Tar));

--- a/.github/scripts/build.mjs
+++ b/.github/scripts/build.mjs
@@ -83,8 +83,10 @@ async function buildBindings(args, pkg) {
 
   if (process.platform === 'darwin' && process.arch === 'arm64') {
     // The "arm64" build is actually a universal binary
-    const armTar = `kerberos-v${pkg.version}-napi-v4-darwin-arm64.tar.gz`;
-    const x64Tar = `kerberos-v${pkg.version}-napi-v4-darwin-x64.tar.gz`;
+    // @ts-ignore
+    const napiVersion = require('../../package.json').binary.napi_versions[0];
+    const armTar = `kerberos-v${pkg.version}-napi-v${napiVersion}-darwin-arm64.tar.gz`;
+    const x64Tar = `kerberos-v${pkg.version}-napi-v${napiVersion}-darwin-x64.tar.gz`;
     await fs.copyFile(resolveRoot('prebuilds', armTar), resolveRoot('prebuilds', x64Tar));
   }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-2022]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +41,7 @@ jobs:
     strategy:
       matrix:
         linux_arch: [s390x, arm64, amd64]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
 
@@ -69,6 +71,7 @@ jobs:
     strategy:
       matrix:
         freebsd_arch: [aarch64, amd64]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -22,10 +22,6 @@ jobs:
       shell: bash
       run: |
         npm install --ignore-scripts
-    - name: "Install necessary gssapi C++ dependencies"
-      shell: bash
-      run: |
-        apt-get -qq update && apt-get -qq install -y python3 build-essential libkrb5-dev && ldd --version
 
     - name: "Install dependencies in the Webpack bundle test package"
       shell: bash

--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -21,7 +21,7 @@ jobs:
     - name: "Install dependencies"
       shell: bash
       run: |
-        npm install
+        npm install --ignore-scripts
 
     - name: "Install dependencies in the Webpack bundle test package"
       shell: bash

--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -22,6 +22,10 @@ jobs:
       shell: bash
       run: |
         npm install --ignore-scripts
+    - name: "Install necessary gssapi C++ dependencies"
+      shell: bash
+      run: |
+        apt-get -qq update && apt-get -qq install -y python3 build-essential libkrb5-dev && ldd --version
 
     - name: "Install dependencies in the Webpack bundle test package"
       shell: bash

--- a/lib/index.js
+++ b/lib/index.js
@@ -224,6 +224,11 @@ async function initializeServer(service) {
   return await promisifiedInitializeServer.call(this, service);
 }
 
+/**
+ * @private
+ *
+ * The NAPI version kerberos is configured to use, defined in kerberos.h.
+ */
 const definedNapiVersion = kerberos.definedNapiVersion;
 
 module.exports = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -224,9 +224,6 @@ async function initializeServer(service) {
   return await promisifiedInitializeServer.call(this, service);
 }
 
-/**
- * @internal
- */
 const napiVersion = kerberos.napiVersion;
 
 module.exports = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -224,7 +224,7 @@ async function initializeServer(service) {
   return await promisifiedInitializeServer.call(this, service);
 }
 
-const napiVersion = kerberos.napiVersion;
+const definedNapiVersion = kerberos.definedNapiVersion;
 
 module.exports = {
   initializeClient,
@@ -249,5 +249,5 @@ module.exports = {
   GSS_MECH_OID_SPNEGO,
 
   version,
-  napiVersion
+  definedNapiVersion
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -224,6 +224,11 @@ async function initializeServer(service) {
   return await promisifiedInitializeServer.call(this, service);
 }
 
+/**
+ * @internal
+ */
+const napiVersion = kerberos.napiVersion;
+
 module.exports = {
   initializeClient,
   initializeServer,
@@ -246,5 +251,6 @@ module.exports = {
   GSS_MECH_OID_KRB5,
   GSS_MECH_OID_SPNEGO,
 
-  version
+  version,
+  napiVersion
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "node-addon-api": "^6.1.0",
+        "node-addon-api": "^8.5.0",
         "prebuild-install": "^7.1.3"
       },
       "devDependencies": {
@@ -4168,9 +4168,13 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/node-api-headers": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "binary": {
     "napi_versions": [
-      4
+      9
     ]
   },
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://jira.mongodb.org/projects/NODE/issues/"
   },
   "dependencies": {
-    "node-addon-api": "^6.1.0",
+    "node-addon-api": "^8.5.0",
     "prebuild-install": "^7.1.3"
   },
   "devDependencies": {

--- a/src/kerberos.cc
+++ b/src/kerberos.cc
@@ -1,4 +1,5 @@
 #include "kerberos.h"
+
 #include "kerberos_worker.h"
 
 /// KerberosClient
@@ -13,8 +14,8 @@ struct InstanceData {
 };
 
 static constexpr napi_property_attributes writable_and_configurable =
-    static_cast<napi_property_attributes>(
-        static_cast<int>(napi_writable) | static_cast<int>(napi_configurable));
+    static_cast<napi_property_attributes>(static_cast<int>(napi_writable) |
+                                          static_cast<int>(napi_configurable));
 
 inline String NewMaybeWideString(Env env, const char* str) {
     return String::New(env, str);
@@ -22,13 +23,13 @@ inline String NewMaybeWideString(Env env, const char* str) {
 #ifdef _WIN32
 inline String NewMaybeWideString(Env env, const WCHAR* str) {
     static_assert(sizeof(std::wstring::value_type) == sizeof(std::u16string::value_type),
-        "wstring and u16string have the same value type on Windows");
+                  "wstring and u16string have the same value type on Windows");
     std::wstring wstr(str);
     std::u16string u16(wstr.begin(), wstr.end());
     return String::New(env, u16);
 }
 #endif
-}
+}  // namespace
 
 std::string ToStringWithNonStringAsEmpty(Napi::Value value) {
     if (!value.IsString()) {
@@ -38,7 +39,8 @@ std::string ToStringWithNonStringAsEmpty(Napi::Value value) {
 }
 
 int KerberosClient::ParseWrapOptionsProtect(const Napi::Object& options) {
-    if (!options.Has("protect"))    return 0;
+    if (!options.Has("protect"))
+        return 0;
 
     if (!options.Get("protect").IsBoolean()) {
         throw TypeError::New(options.Env(), "options.protect must be a boolean.");
@@ -49,18 +51,16 @@ int KerberosClient::ParseWrapOptionsProtect(const Napi::Object& options) {
 }
 
 Function KerberosClient::Init(Napi::Env env) {
-    return
-        DefineClass(env,
-                    "KerberosClient",
-                    {
-                      InstanceMethod("step", &KerberosClient::Step, writable_and_configurable),
-                      InstanceMethod("wrap", &KerberosClient::WrapData, writable_and_configurable),
-                      InstanceMethod("unwrap", &KerberosClient::UnwrapData, writable_and_configurable),
-                      InstanceAccessor("username", &KerberosClient::UserNameGetter, nullptr),
-                      InstanceAccessor("response", &KerberosClient::ResponseGetter, nullptr),
-                      InstanceAccessor("responseConf", &KerberosClient::ResponseConfGetter, nullptr),
-                      InstanceAccessor("contextComplete", &KerberosClient::ContextCompleteGetter, nullptr)
-                    });
+    return DefineClass(
+        env,
+        "KerberosClient",
+        {InstanceMethod("step", &KerberosClient::Step, writable_and_configurable),
+         InstanceMethod("wrap", &KerberosClient::WrapData, writable_and_configurable),
+         InstanceMethod("unwrap", &KerberosClient::UnwrapData, writable_and_configurable),
+         InstanceAccessor("username", &KerberosClient::UserNameGetter, nullptr),
+         InstanceAccessor("response", &KerberosClient::ResponseGetter, nullptr),
+         InstanceAccessor("responseConf", &KerberosClient::ResponseConfGetter, nullptr),
+         InstanceAccessor("contextComplete", &KerberosClient::ContextCompleteGetter, nullptr)});
 }
 
 Object KerberosClient::NewInstance(Napi::Env env, std::shared_ptr<krb_client_state> state) {
@@ -71,8 +71,7 @@ Object KerberosClient::NewInstance(Napi::Env env, std::shared_ptr<krb_client_sta
     return obj;
 }
 
-KerberosClient::KerberosClient(const CallbackInfo& info)
-    : ObjectWrap(info) {}
+KerberosClient::KerberosClient(const CallbackInfo& info) : ObjectWrap(info) {}
 
 std::shared_ptr<krb_client_state> KerberosClient::state() const {
     return _state;
@@ -102,16 +101,14 @@ Value KerberosClient::ContextCompleteGetter(const CallbackInfo& info) {
 
 /// KerberosServer
 Function KerberosServer::Init(Napi::Env env) {
-    return
-        DefineClass(env,
-                    "KerberosServer",
-                    {
-                      InstanceMethod("step", &KerberosServer::Step, writable_and_configurable),
-                      InstanceAccessor("username", &KerberosServer::UserNameGetter, nullptr),
-                      InstanceAccessor("response", &KerberosServer::ResponseGetter, nullptr),
-                      InstanceAccessor("targetName", &KerberosServer::TargetNameGetter, nullptr),
-                      InstanceAccessor("contextComplete", &KerberosServer::ContextCompleteGetter, nullptr)
-                    });
+    return DefineClass(
+        env,
+        "KerberosServer",
+        {InstanceMethod("step", &KerberosServer::Step, writable_and_configurable),
+         InstanceAccessor("username", &KerberosServer::UserNameGetter, nullptr),
+         InstanceAccessor("response", &KerberosServer::ResponseGetter, nullptr),
+         InstanceAccessor("targetName", &KerberosServer::TargetNameGetter, nullptr),
+         InstanceAccessor("contextComplete", &KerberosServer::ContextCompleteGetter, nullptr)});
 }
 
 Object KerberosServer::NewInstance(Napi::Env env, std::shared_ptr<krb_server_state> state) {
@@ -122,8 +119,7 @@ Object KerberosServer::NewInstance(Napi::Env env, std::shared_ptr<krb_server_sta
     return obj;
 }
 
-KerberosServer::KerberosServer(const CallbackInfo& info)
-    : ObjectWrap(info) {}
+KerberosServer::KerberosServer(const CallbackInfo& info) : ObjectWrap(info) {}
 
 std::shared_ptr<krb_server_state> KerberosServer::state() const {
     return _state;
@@ -154,7 +150,7 @@ Value KerberosServer::ContextCompleteGetter(const CallbackInfo& info) {
     return Boolean::New(Env(), state()->context_complete);
 }
 
-Value GetNapiVersion(const CallbackInfo& info) {
+Value GetDefinedNapiVersion(const CallbackInfo& info) {
     return String::New(info.Env(), std::to_string(NAPI_VERSION));
 }
 
@@ -173,7 +169,7 @@ static Object Init(Env env, Object exports) {
     exports["initializeServer"] = Function::New(env, InitializeServer);
     exports["principalDetails"] = Function::New(env, PrincipalDetails);
     exports["checkPassword"] = Function::New(env, CheckPassword);
-    exports["napiVersion"] = Function::New(env, GetNapiVersion);
+    exports["definedNapiVersion"] = Function::New(env, GetDefinedNapiVersion);
     return exports;
 }
 

--- a/src/kerberos.h
+++ b/src/kerberos.h
@@ -1,15 +1,10 @@
 #ifndef KERBEROS_NATIVE_EXTENSION_H
 #define KERBEROS_NATIVE_EXTENSION_H
 
-// We generally only target N-API version 4, but the instance data
-// feature is only available in N-API version 6. However, it is
-// available in all Node.js versions that have N-API version 4
-#define NAPI_VERSION 6
-// as an experimental feature (that has not been changed since then).
-#define NAPI_EXPERIMENTAL
-#define NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT
+#define NAPI_VERSION 9
 
 #include <napi.h>
+
 #include "kerberos_common.h"
 
 namespace node_kerberos {
@@ -74,6 +69,6 @@ void TestMethod(const Napi::CallbackInfo& info);
 
 std::string ToStringWithNonStringAsEmpty(Napi::Value value);
 
-}
+}  // namespace node_kerberos
 
 #endif  // KERBEROS_NATIVE_EXTENSION_H

--- a/src/kerberos.h
+++ b/src/kerberos.h
@@ -66,7 +66,7 @@ void CheckPassword(const Napi::CallbackInfo& info);
 
 std::string ToStringWithNonStringAsEmpty(Napi::Value value);
 
-Napi::Value GetNapiVersion(const Napi::CallbackInfo& info);
+Napi::Value GetDefinedNapiVersion(const Napi::CallbackInfo& info);
 
 }  // namespace node_kerberos
 

--- a/src/kerberos.h
+++ b/src/kerberos.h
@@ -64,10 +64,9 @@ void InitializeClient(const Napi::CallbackInfo& info);
 void InitializeServer(const Napi::CallbackInfo& info);
 void CheckPassword(const Napi::CallbackInfo& info);
 
-// NOTE: explicitly used for unit testing `defineOperation`, not meant to be exported
-void TestMethod(const Napi::CallbackInfo& info);
-
 std::string ToStringWithNonStringAsEmpty(Napi::Value value);
+
+Napi::Value GetNapiVersion(const Napi::CallbackInfo& info);
 
 }  // namespace node_kerberos
 

--- a/test/bundling/webpack/install_kerberos.cjs
+++ b/test/bundling/webpack/install_kerberos.cjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict';
 
 const { execSync } = require('node:child_process');
@@ -19,6 +20,7 @@ console.log(`kerberos Version: ${kerberosVersion}`);
 
 xtrace('npm pack --pack-destination test/bundling/webpack', { cwd: kerberosRoot });
 
-xtrace(`npm install --no-save kerberos-${kerberosVersion}.tgz`);
+// --ignore-scripts: don't worry about downloading prebuilt binaries, we're only bundling
+xtrace(`npm install --ignore-scripts --no-save kerberos-${kerberosVersion}.tgz`);
 
 console.log('kerberos installed!');

--- a/test/kerberos_tests.js
+++ b/test/kerberos_tests.js
@@ -222,7 +222,7 @@ describe('Kerberos', function () {
     });
   });
 
-  it('napiVersion() returns 9', function () {
-    expect(kerberos.napiVersion()).to.equal('9');
+  it('definedNapiVersion() returns 9', function () {
+    expect(kerberos.definedNapiVersion()).to.equal('9');
   });
 });

--- a/test/kerberos_tests.js
+++ b/test/kerberos_tests.js
@@ -221,4 +221,8 @@ describe('Kerberos', function () {
       });
     });
   });
+
+  it('napiVersion() returns 9', function () {
+    expect(kerberos.napiVersion()).to.equal('9');
+  });
 });


### PR DESCRIPTION
### Description

#### Summary of Changes

This PR increases the napi version to 9.  Additionally, it adds an internal napi C++/ JS function which returns the napi version, just to assert in tests that we are using the correct napi version.

##### Notes for Reviewers

The webpack tests started failing with this change because `npm i` was trying to install prebuilds for kerberos.  The download url for each prebuild includes the napi version, and because we have not yet released a version of kerberos using napi v9, this failed.

I resolved this issue by using `--ignore-scripts`, which is okay to use here because we don't actually need prebuilds to test the bundling step.

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motiviation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### kerberos' napi version has been increased to 9

kerberos' napi version has been increased to 9.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
