### PR TITLE
fix(NODE-7226): build glibc prebuilds on platforms with libc 2.28

### DIFF
--- a/.github/docker/Dockerfile.glibc
+++ b/.github/docker/Dockerfile.glibc
@@ -1,4 +1,4 @@
-FROM ubuntu:noble AS build
+FROM redhat/ubi8 AS build
 
 # Possible values: s390x, arm64, x64
 ARG NODE_ARCH
@@ -9,7 +9,9 @@ ENV PATH=$PATH:/nodejs/bin
 WORKDIR /kerberos
 COPY . .
 
-RUN apt-get -qq update && apt-get -qq install -y python3 build-essential libkrb5-dev && ldd --version
+RUN yum install -y python39 git make gcc-c++ krb5-devel
+
+RUN if [[ $(ldd --version) =~ "2.28" ]]; then  echo "using glibc 2.28"; else echo "glibc version is not 2.28.  bailing..." && exit 1; fi
 
 RUN node .github/scripts/build.mjs
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm install kerberos
 Below are the platforms that are available as prebuilds on each github release.
 `prebuild-install` downloads these automatically depending on the platform you are running npm install on.
 
-- Linux GLIBC 2.23 or later
+- Linux GLIBC 2.28 or later
 - s390x
 - arm64
 - x64

--- a/etc/README.hbs
+++ b/etc/README.hbs
@@ -59,7 +59,7 @@ npm install kerberos
 Below are the platforms that are available as prebuilds on each github release.
 `prebuild-install` downloads these automatically depending on the platform you are running npm install on.
 
-- Linux GLIBC 2.23 or later
+- Linux GLIBC 2.28 or later
 - s390x
 - arm64
 - x64


### PR DESCRIPTION
### Description

#### Summary of Changes

<!-- Please describe the changes in this PR in a high-level overview. -->

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motiviation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Release notes highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
