### PR TITLE
feat(NODE-7338): support building win32-arm64 prebuild

### DIFF
--- a/.github/scripts/build.mjs
+++ b/.github/scripts/build.mjs
@@ -20,6 +20,7 @@ async function parseArguments() {
 
   const options = {
     'kerberos_use_rtld': { type: 'boolean', default: true },
+    arch: { short: 'a', type: 'string', default: '' },
     help: { short: 'h', type: 'boolean', default: false }
   };
 
@@ -37,6 +38,7 @@ async function parseArguments() {
 
   return {
     kerberos_use_rtld: !!args.values.kerberos_use_rtld,
+    arch: args.values.arch || '',
     pkg
   };
 }
@@ -76,7 +78,12 @@ async function buildBindings(args, pkg) {
       ? { env: { ...process.env, GYP_DEFINES: gypDefines } }
       : undefined;
 
-  await run('npm', ['run', 'prebuild'], prebuildOptions);
+  const prebuildArgs = ['run', 'prebuild'];
+  if (args.arch) {
+    prebuildArgs.push('--', '--arch', args.arch);
+  }
+
+  await run('npm', prebuildArgs, prebuildOptions);
 
   // TODO(NODE-5140): When we have a TS build step
   // await run('npm', ['run', 'prepare']);
@@ -96,7 +103,7 @@ async function buildBindings(args, pkg) {
     await fs.copyFile(resolveRoot('prebuilds', armTar), resolveRoot('prebuilds', x64Tar));
   }
 
-  await run('node', ['--print', `require('.')`], { cwd: resolveRoot() })
+  await run('node', ['--print', `require('.')`], { cwd: resolveRoot() });
 }
 
 async function main() {

--- a/.github/scripts/build.mjs
+++ b/.github/scripts/build.mjs
@@ -20,7 +20,6 @@ async function parseArguments() {
 
   const options = {
     'kerberos_use_rtld': { type: 'boolean', default: true },
-    arch: { short: 'a', type: 'string', default: '' },
     help: { short: 'h', type: 'boolean', default: false }
   };
 
@@ -38,7 +37,6 @@ async function parseArguments() {
 
   return {
     kerberos_use_rtld: !!args.values.kerberos_use_rtld,
-    arch: args.values.arch || '',
     pkg
   };
 }
@@ -78,12 +76,7 @@ async function buildBindings(args, pkg) {
       ? { env: { ...process.env, GYP_DEFINES: gypDefines } }
       : undefined;
 
-  const prebuildArgs = ['run', 'prebuild'];
-  if (args.arch) {
-    prebuildArgs.push('--', '--arch', args.arch);
-  }
-
-  await run('npm', prebuildArgs, prebuildOptions);
+  await run('npm', ['run', 'prebuild'], prebuildOptions);
 
   // TODO(NODE-5140): When we have a TS build step
   // await run('npm', ['run', 'prepare']);

--- a/.github/scripts/build.mjs
+++ b/.github/scripts/build.mjs
@@ -20,6 +20,7 @@ async function parseArguments() {
 
   const options = {
     'kerberos_use_rtld': { type: 'boolean', default: true },
+    arch: { short: 'a', type: 'string', default: '' },
     help: { short: 'h', type: 'boolean', default: false }
   };
 
@@ -37,6 +38,7 @@ async function parseArguments() {
 
   return {
     kerberos_use_rtld: !!args.values.kerberos_use_rtld,
+    arch: args.values.arch || '',
     pkg
   };
 }
@@ -76,7 +78,12 @@ async function buildBindings(args, pkg) {
       ? { env: { ...process.env, GYP_DEFINES: gypDefines } }
       : undefined;
 
-  await run('npm', ['run', 'prebuild'], prebuildOptions);
+  const prebuildArgs = ['run', 'prebuild'];
+  if (args.arch) {
+    prebuildArgs.push('--', '--arch', args.arch);
+  }
+
+  await run('npm', prebuildArgs, prebuildOptions);
 
   // TODO(NODE-5140): When we have a TS build step
   // await run('npm', ['run', 'prepare']);

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,20 +15,27 @@ jobs:
   host_builds:
     strategy:
       matrix:
-        os: [macos-latest, windows-2022]
+        include:
+          - os: macos-latest
+            arch: ''
+          - os: windows-2022
+            arch: ''
+          - os: windows-2022
+            arch: arm64
+            runs_on: windows-11-arm
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runs_on || matrix.os }}
     steps:
       - uses: actions/checkout@v5
 
-      - name: Build ${{ matrix.os }} Prebuild
-        run: node .github/scripts/build.mjs
+      - name: Build ${{ matrix.os }}${{ matrix.arch && format(' {0}', matrix.arch) || '' }} Prebuild
+        run: node .github/scripts/build.mjs${{ matrix.arch && format(' --arch {0}', matrix.arch) || '' }}
 
       - id: upload
         name: Upload prebuild
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.os }}
+          name: build-${{ matrix.os }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }}
           path: prebuilds/
           if-no-files-found: 'error'
           retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,27 +15,20 @@ jobs:
   host_builds:
     strategy:
       matrix:
-        include:
-          - os: macos-latest
-            arch: ''
-          - os: windows-2022
-            arch: ''
-          - os: windows-2022
-            arch: arm64
-            runs_on: windows-11-arm
+        os: [macos-latest, windows-2022, windows-11-arm]
       fail-fast: false
-    runs-on: ${{ matrix.runs_on || matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
 
-      - name: Build ${{ matrix.os }}${{ matrix.arch && format(' {0}', matrix.arch) || '' }} Prebuild
-        run: node .github/scripts/build.mjs${{ matrix.arch && format(' --arch {0}', matrix.arch) || '' }}
+      - name: Build ${{ matrix.os }} Prebuild
+        run: node .github/scripts/build.mjs
 
       - id: upload
         name: Upload prebuild
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.os }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }}
+          name: build-${{ matrix.os }}
           path: prebuilds/
           if-no-files-found: 'error'
           retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,18 +17,18 @@ jobs:
       matrix:
         os: [macos-latest, windows-2022, windows-11-arm]
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runs_on || matrix.os }}
     steps:
       - uses: actions/checkout@v5
 
-      - name: Build ${{ matrix.os }} Prebuild
-        run: node .github/scripts/build.mjs
+      - name: Build ${{ matrix.os }}${{ matrix.arch && format(' {0}', matrix.arch) || '' }} Prebuild
+        run: node .github/scripts/build.mjs${{ matrix.arch && format(' --arch {0}', matrix.arch) || '' }}
 
       - id: upload
         name: Upload prebuild
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.os }}
+          name: build-${{ matrix.os }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }}
           path: prebuilds/
           if-no-files-found: 'error'
           retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,18 +17,18 @@ jobs:
       matrix:
         os: [macos-latest, windows-2022, windows-11-arm]
       fail-fast: false
-    runs-on: ${{ matrix.runs_on || matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
 
-      - name: Build ${{ matrix.os }}${{ matrix.arch && format(' {0}', matrix.arch) || '' }} Prebuild
-        run: node .github/scripts/build.mjs${{ matrix.arch && format(' --arch {0}', matrix.arch) || '' }}
+      - name: Build ${{ matrix.os }} Prebuild
+        run: node .github/scripts/build.mjs
 
       - id: upload
         name: Upload prebuild
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.os }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }}
+          name: build-${{ matrix.os }}
           path: prebuilds/
           if-no-files-found: 'error'
           retention-days: 1

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Below are the platforms that are available as prebuilds on each github release.
 - arm64
 - Windows
 - x64
+- arm64
 
 ### Release Integrity
 

--- a/README.md
+++ b/README.md
@@ -55,21 +55,29 @@ Now you can install `kerberos` with the following:
 npm install kerberos
 ```
 
+#### Support Strategy
+
+There are two support tiers:
+
+- **Tier 1**: These platforms represent the majority of our users. Test failures on tier 1 platforms will block
+releases.
+- **Experimental**: Test suite may not exist or may not pass. Test failures on experimental platforms
+do not block releases. Contributions to improve support for these platforms are welcome.
+
 #### Prebuild Platforms
 
 Below are the platforms that are available as prebuilds on each github release.
 `prebuild-install` downloads these automatically depending on the platform you are running npm install on.
 
-- Linux GLIBC 2.28 or later
-- s390x
-- arm64
-- x64
-- MacOS universal binary
-- x64
-- arm64
-- Windows
-- x64
-- arm64
+| Operating System          | Platform | Support Type |
+| ------------------------- | -------- | ------------ |
+| Linux GLIBC 2.28 or later |    s390x |       Tier 1 |
+| Linux GLIBC 2.28 or later |    arm64 |       Tier 1 |
+| Linux GLIBC 2.28 or later |      x64 |       Tier 1 |
+| MacOS universal binary    |      x64 |       Tier 1 |
+| MacOS universal binary    |    arm64 |       Tier 1 |
+| Windows                   |      x64 |       Tier 1 |
+| Windows                   |    arm64 | Experimental |
 
 ### Release Integrity
 

--- a/etc/README.hbs
+++ b/etc/README.hbs
@@ -55,20 +55,28 @@ Now you can install `kerberos` with the following:
 npm install kerberos
 ```
 
+#### Support Strategy
+
+There are two support tiers:
+
+- **Tier 1**: These platforms represent the majority of our users. Test failures on tier 1 platforms will block
+releases.
+- **Experimental**: Test suite may not exist or may not pass. Test failures on experimental platforms
+do not block releases. Contributions to improve support for these platforms are welcome.
+
 #### Prebuild Platforms
 
 Below are the platforms that are available as prebuilds on each github release.
 `prebuild-install` downloads these automatically depending on the platform you are running npm install on.
 
-- Linux GLIBC 2.28 or later
-- s390x
-- arm64
-- x64
-- MacOS universal binary
-- x64
-- arm64
-- Windows
-- x64
+| Operating System          | Platform | Support Type |
+| ------------------------- | -------- | ------------ |
+| Linux GLIBC 2.28 or later |    s390x |       Tier 1 |
+| Linux GLIBC 2.28 or later |    arm64 |       Tier 1 |
+| Linux GLIBC 2.28 or later |      x64 |       Tier 1 |
+| MacOS universal binary    |      x64 |       Tier 1 |
+| MacOS universal binary    |    arm64 |       Tier 1 |
+| Windows                   |      x64 |       Tier 1 |
 
 ### Release Integrity
 

--- a/etc/README.hbs
+++ b/etc/README.hbs
@@ -77,6 +77,7 @@ Below are the platforms that are available as prebuilds on each github release.
 | MacOS universal binary    |      x64 |       Tier 1 |
 | MacOS universal binary    |    arm64 |       Tier 1 |
 | Windows                   |      x64 |       Tier 1 |
+| Windows                   |    arm64 | Experimental |
 
 ### Release Integrity
 


### PR DESCRIPTION
### Description

#### Summary of Changes

Add support for win32-arm64 prebuild.

##### Notes for Reviewers


#### What is the motivation for this change?

Since Windows ARM platform is going to be more and more popular, so add support for it.

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Windows arm64 experimental support added

Add support for win32-arm64 prebuild.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
