### PR TITLE
fix(NODE-7395): do not export mech_oid symbols

### DIFF
--- a/src/unix/kerberos_unix.cc
+++ b/src/unix/kerberos_unix.cc
@@ -11,10 +11,10 @@ using namespace Napi;
 #define GSS_MECH_OID_SPNEGO 6
 
 static char krb5_mech_oid_bytes[] = "\x2a\x86\x48\x86\xf7\x12\x01\x02\x02";
-gss_OID_desc krb5_mech_oid = {9, &krb5_mech_oid_bytes};
+static gss_OID_desc krb5_mech_oid = {9, &krb5_mech_oid_bytes};
 
 static char spnego_mech_oid_bytes[] = "\x2b\x06\x01\x05\x05\x02";
-gss_OID_desc spnego_mech_oid = {6, &spnego_mech_oid_bytes};
+static gss_OID_desc spnego_mech_oid = {6, &spnego_mech_oid_bytes};
 
 /// KerberosClient
 void KerberosClient::Step(const CallbackInfo& info) {


### PR DESCRIPTION
### Description

#### Summary of Changes

As described in the ticket, this fixes mongosh's build on x64 macOS with Node.js 24, even though we haven't fully investigated why that is the case.

Making these variables `static` is a good idea anyway since they are not meant to be used by other compilation units or loaded from the kerberos addon.

Without this patch, we receive:

    [2026/01/15 12:18:50.271] ld: warning: alignment (2) of atom '__ZN13node_kerberos15spnego_mech_oidE' is too small and may result in unaligned pointers
    [2026/01/15 12:18:50.271] ld: warning: alignment (2) of atom '__ZN13node_kerberos13krb5_mech_oidE' is too small and may result in unaligned pointers
    [2026/01/15 12:18:50.946] ld: warning: pointer not aligned at address 0x10945A92E ('node_kerberos::krb5_mech_oid' + 4 from /private/tmp/m/boxednode/<REDACTED:notary_signing_key_name>/node-v24.12.0/out/Release/kerberos.a(kerberos_unix.o))
    [2026/01/15 12:18:50.946] ld: warning: pointer not aligned at address 0x10945A942 ('node_kerberos::spnego_mech_oid' + 4 from /private/tmp/m/boxednode/<REDACTED:notary_signing_key_name>/node-v24.12.0/out/Release/kerberos.a(kerberos_unix.o))
    [2026/01/15 12:18:51.115] ld: unaligned pointer(s) for architecture x86_64
    [2026/01/15 12:18:51.115] clang++: error: linker command failed with exit code 1 (use -v to see invocation)

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
