### PR TITLE
feat(NODE-7403): enable more build warnings on Windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -29,6 +29,9 @@
           'ExceptionHandling': 1,
           'AdditionalOptions': [
             '/guard:cf',
+            '/sdl',
+            '/W3',
+            '/w34146',
             '/w34244',
             '/w34267',
             '/ZH:SHA_256'


### PR DESCRIPTION
### Description

#### Summary of Changes

This PR enables more build warnings on Windows and is a follow-up to https://github.com/mongodb-js/kerberos/pull/190.

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
