### PR TITLE
feat(NODE-7404): enable stack-protector-strong flag on Linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -21,8 +21,6 @@
       },
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
-      'cflags': [ '-fstack-protector-strong' ],
-      'cflags_cc': [ '-fstack-protector-strong' ],
       'msvs_configuration_attributes': {
         'SpectreMitigation': 'Spectre'
       },
@@ -43,6 +41,10 @@
         }
       },
       'conditions': [
+        ['OS!="win"', {
+          'cflags': ['-fstack-protector-strong'],
+          'cflags_cc': ['-fstack-protector-strong']
+        }],
         ['OS=="mac"', { 'cflags+': ['-fvisibility=hidden'] }],
         ['_type!="static_library" and ARCH=="arm64"', {
           'xcode_settings': {

--- a/binding.gyp
+++ b/binding.gyp
@@ -21,6 +21,8 @@
       },
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
+      'cflags': [ '-fstack-protector-strong' ],
+      'cflags_cc': [ '-fstack-protector-strong' ],
       'msvs_configuration_attributes': {
         'SpectreMitigation': 'Spectre'
       },


### PR DESCRIPTION
### Description

#### Summary of Changes

This PR enables stack canaries on Linux and is a follow-up to https://github.com/mongodb-js/kerberos/pull/190.

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
