### PR TITLE
chore(NODE-7567): migrate release workflow to npm Trusted Publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           arch: ${{ matrix.freebsd_arch }}
           usesh: true
           prepare: |
-            pkg install -y krb5 node npm pkgconf
+            pkg install -y krb5 node npm pkgconf python3
           run: |
             node .github/scripts/build.mjs
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 name: release-latest
 
@@ -90,6 +89,9 @@ jobs:
 
   publish:
     needs: [release_please, ssdlc, build]
+    permissions:
+      id-token: write
+      contents: read
     environment: release
     runs-on: ubuntu-latest
     steps:
@@ -102,5 +104,3 @@ jobs:
 
       - run: npm publish --provenance --tag latest
         if: ${{ needs.release_please.outputs.release_created }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description

#### Summary of Changes

Migrate `kerberos` off `NPM_TOKEN` and onto npm Trusted Publishing (OIDC) per [NODE-7567](https://jira.mongodb.org/browse/NODE-7567).

Since this repo has a single release workflow, `release.yml` is registered directly as the trusted publisher on npmjs.com — no separate `npm-publish.yml` indirection needed.

- Add `id-token: write` to the `publish` job (job-level, least-privilege). The `ssdlc` job already has its own `id-token: write` for AWS OIDC.
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`; `npm publish --provenance` obtains the OIDC token automatically.
- Top-level permissions retain only `contents: write` and `pull-requests: write`.

##### Notes for Reviewers

**Before merging:** An npm Trusted Publishing entry must be configured on npmjs.com for the `kerberos` package, pointing at `release.yml` in this repo. Once verified, `NPM_TOKEN` can be removed from the repo secrets and the package switched to "Require two-factor authentication and disallow tokens."

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket