### PR TITLE
chore: fix release job, remove unused id-token permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,7 @@ on:
 name: Build and Test
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
 
 jobs:
   host_builds:


### PR DESCRIPTION
### Description

#### Summary of Changes

<!-- Please describe the changes in this PR in a high-level overview. -->

Reduce build.yml workflow permissions to the minimum required (`contents: read`), removing `contents: write`, `pull-requests: write`, and `id-token: write`.

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

Same issue as mongodb-js/mongodb-client-encryption#129 - reusable workflow called via `workflow_call` cannot request more permissions than the caller grants. `release.yml` grants only `contents: write` and `pull-requests: write` (no `id-token`), so calling `build.yml` which declares `id-token: write` fails with:
```
> The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

The three jobs in `build.yml` (`host_builds`, `container_builds`, `freebsd_builds`) only checkout, build native binaries, and upload artifacts - none require write access to the repo or pull requests. `contents: read` is sufficient for `actions/checkout`.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
