### PR TITLE
chore(NODE-7599): tighten workflow permissions and update docs

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -7,9 +7,7 @@ on:
 name: Build and Test
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
 
 jobs:
   check_docs:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Below are the platforms that are available as prebuilds on each github release.
 ### Release Integrity
 
 Releases are created automatically and signed using the [Node team's GPG key](https://pgp.mongodb.com/node-driver.asc).
-This applies to the git tag as well as all release packages provided as part of a GitHub release. To verify the provided
+All release packages provided as part of a GitHub release are signed. To verify the provided
 packages, download the key and import it using gpg:
 
 ```
@@ -105,11 +105,17 @@ gpg --verify kerberos-X.Y.Z.tgz.sig kerberos-X.Y.Z.tgz
 ```
 
 >[!Note]
-No verification is done when using npm to install the package. To ensure release integrity when using npm, download the
+No GPG verification is done when using npm to install the package. To ensure release integrity when using npm, download the
 tarball manually from the GitHub release, verify the signature, then install the package from the downloaded tarball
-using npm install mongodb-X.Y.Z.tgz.
+using npm install kerberos-X.Y.Z.tgz.
 
 To verify the native `.node` packages, follow the same steps as above.
+
+Releases published to the npm registry also include a [provenance attestation](https://docs.npmjs.com/generating-provenance-statements), which cryptographically links the package to its source repository and build workflow. To verify provenance:
+
+```shell
+npm audit signatures
+```
 
 ### Testing
 

--- a/etc/README.hbs
+++ b/etc/README.hbs
@@ -82,7 +82,7 @@ Below are the platforms that are available as prebuilds on each github release.
 ### Release Integrity
 
 Releases are created automatically and signed using the [Node team's GPG key](https://pgp.mongodb.com/node-driver.asc).
-This applies to the git tag as well as all release packages provided as part of a GitHub release. To verify the provided
+All release packages provided as part of a GitHub release are signed. To verify the provided
 packages, download the key and import it using gpg:
 
 ```
@@ -105,11 +105,17 @@ gpg --verify kerberos-X.Y.Z.tgz.sig kerberos-X.Y.Z.tgz
 ```
 
 >[!Note]
-No verification is done when using npm to install the package. To ensure release integrity when using npm, download the
+No GPG verification is done when using npm to install the package. To ensure release integrity when using npm, download the
 tarball manually from the GitHub release, verify the signature, then install the package from the downloaded tarball
-using npm install mongodb-X.Y.Z.tgz.
+using npm install kerberos-X.Y.Z.tgz.
 
 To verify the native `.node` packages, follow the same steps as above.
+
+Releases published to the npm registry also include a [provenance attestation](https://docs.npmjs.com/generating-provenance-statements), which cryptographically links the package to its source repository and build workflow. To verify provenance:
+
+```shell
+npm audit signatures
+```
 
 ### Testing
 


### PR DESCRIPTION
### Description

#### Summary of Changes

Two maintenance changes.

<!-- Please describe the changes in this PR in a high-level overview. -->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

The `README` has had a copy-paste error since it was introduced and an incorrect claim about git tag signing. The `check-docs.yml` permissions were overly broad, violating the principle of least privilege - and since the workflow has a `workflow_call` trigger, it could cause validation failures if ever called from a workflow that doesn't grant those permissions.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
