### PR TITLE
chore(NODE-7526): group dependabot updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,20 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "monthly"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    groups:
+      github-actions:
+        patterns: ["*"]
+        applies-to: both
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "monthly"
     ignore:
@@ -28,17 +36,28 @@ updates:
       # node-gyp now depends on python 3.10, we install 3.6 in our dockerfile
       - dependency-name: "node-gyp"
       - dependency-name: "prebuild"
-      
     groups:
-      prod-dependencies:
+      production-dependencies:
         dependency-type: "production"
-        applies-to: version-updates
+        applies-to: both
         update-types:
-        - "minor"
-        - "patch"
+          - "minor"
+          - "patch"
       development-dependencies:
         dependency-type: "development"
-        applies-to: version-updates
+        applies-to: both
         update-types:
-        - "minor"
-        - "patch"
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/test/bundling/webpack"
+    schedule:
+      interval: "monthly"
+    groups:
+      webpack-test-dependencies:
+        patterns: ["*"]
+        applies-to: both
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
### Description

#### Summary of Changes

Updates `.github/dependabot.yml` to consolidate dependabot PRs:

- **`applies-to: both`** on all groups — previously `version-updates` only (the default), which caused security updates to bypass grouping and arrive as individual PRs. This is why we were seeing separate PRs for lodash, ip-address, etc. even with groups already configured.
- **Add `/test/bundling/webpack` entry** with a `webpack-test-dependencies` group — this directory had no dependabot entry at all, so every package in it generated its own PR.
- **Add `github-actions` group** — the ecosystem entry existed but had no group, so each action bump (checkout, setup-node, upload-artifact, codeql-action) arrived as a separate PR.

**Before:** 5–10 individual PRs per dependabot run  
**After:** at most 4 PRs — one each for GH Actions, root prod deps, root dev deps, webpack test deps

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket