### PR TITLE
ci(NODE-7772): set build-from-source configuration parameter from env

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -6,6 +6,10 @@ set -o errexit  # Exit the script with error if any of the commands fail
 ## 'latest'
 ## a full nodejs version, in the format v<major>.<minor>.patch
 export NODE_LTS_VERSION=${NODE_LTS_VERSION:-20}
+
+# Use the npm bundled with the installed Node.js release instead of upgrading to
+# npm@latest. TODO: npm v12 does not support build-from-source
+export SKIP_NPM_UPGRADE=true
 # npm version can be defined in the environment for cases where we need to install
 # a version lower than latest to support EOL Node versions. When not provided will
 # be handled by this script in drivers tools.

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -7,13 +7,11 @@ set -o errexit  # Exit the script with error if any of the commands fail
 ## a full nodejs version, in the format v<major>.<minor>.patch
 export NODE_LTS_VERSION=${NODE_LTS_VERSION:-20}
 
-# Use the npm bundled with the installed Node.js release instead of upgrading to
-# npm@latest. TODO: npm v12 does not support build-from-source
-export SKIP_NPM_UPGRADE=true
 # npm version can be defined in the environment for cases where we need to install
 # a version lower than latest to support EOL Node versions. When not provided will
 # be handled by this script in drivers tools.
 source $DRIVERS_TOOLS/.evergreen/install-node.sh
 
-npm install --build-from-source
+npm_config_build_from_source=true npm install
+
 ldd build/*/kerberos.node || true


### PR DESCRIPTION
### Description

#### Summary of Changes

npm v12 no longer supports unrecognized args in `npm install` (https://github.com/npm/cli/commit/9e17dc064782ca1a1fd7f549e5a2fc7903f7fe51). This breaks ci installation of dependencies. The flag is carried into prebuild-install (https://github.com/prebuild/prebuild-install/blob/master/README.md) to skip prebuild download. 'build-from-source' is mapped to an npm configuration parameter, which is then read by prebuild-install. This PR uses an alternative way to set npm configuration parameters, working around the throw caused by the update to npm 12.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Release notes highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
